### PR TITLE
build: SDL2 cleanups on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ prince.hof
 *.x86_64
 *.hex
 *.bat
+prince
 
 # Debug files
 *.dSYM/

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ HFILES = common.h config.h data.h proto.h types.h
 OBJ = main.o data.o seg000.o seg001.o seg002.o seg003.o seg004.o seg005.o seg006.o seg007.o seg008.o seg009.o
 BIN = prince
 
-LIBS := $(shell sdl-config --libs) -lSDL_image -lSDL_mixer
-INCS := $(shell sdl-config --cflags)
+LIBS := $(shell pkg-config --libs   sdl2 SDL2_image SDL2_mixer)
+INCS := $(shell pkg-config --cflags sdl2 SDL2_image SDL2_mixer)
 
 CFLAGS += $(INCS) -Wall -std=gnu99
 

--- a/doc/Readme.txt
+++ b/doc/Readme.txt
@@ -122,7 +122,7 @@ Windows:
 
 GNU/Linux:
 	The libraries can be installed with apt-get or a package manager.
-		sudo apt-get install libsdl-image1.2-dev libsdl-mixer1.2-dev
+		sudo apt-get install libsdl2-image-dev libsdl2-mixer-dev
 	Just type the command:
 		make all
 	and the game should compile.


### PR DESCRIPTION
Add "prince" to .gitignore (since it lacks .exe extension on Linux), and
note the changed Debian/Ubuntu package names for SDL2. Makefile updated
for SDL2.