### PR TITLE
Add basic joystick support

### DIFF
--- a/data.h
+++ b/data.h
@@ -527,6 +527,10 @@ extern SDL_Surface* onscreen_surface_;
 extern SDL_Renderer* renderer_;
 extern SDL_Window* window_;
 extern SDL_Texture* sdl_texture_;
+extern SDL_Joystick* sdl_controller_ INIT( = 0 );
+
+extern int joy_states[3] INIT( = { 0, 0, 0 } );
+
 extern int screen_updates_suspended;
 
 #ifndef USE_COMPAT_TIMER

--- a/seg000.c
+++ b/seg000.c
@@ -127,7 +127,6 @@ void __pascal far init_game_main() {
 	hof_read();
 	//sub_16C48();
 	//sub_16C1B();
-	method_7_alloc(-1);
 
 	start_game();
 }
@@ -212,8 +211,8 @@ int __pascal far process_key() {
 	need_show_text = 0;
 	key = key_test_quit();
 
-	sbyte is_shift_pressed = key_states[SDL_SCANCODE_LSHIFT] || key_states[SDL_SCANCODE_RSHIFT];
-	sbyte is_ctrl_pressed = key_states[SDL_SCANCODE_LCTRL] || key_states[SDL_SCANCODE_RCTRL];
+	sbyte is_shift_pressed = key_states[SDL_SCANCODE_LSHIFT] || key_states[SDL_SCANCODE_RSHIFT] | joy_states[2];
+	sbyte is_ctrl_pressed = (key_states[SDL_SCANCODE_LCTRL] || key_states[SDL_SCANCODE_RCTRL]) | joy_states[2];
 
 	if (start_level == 0) {
 		if (key || is_shift_pressed) {
@@ -876,6 +875,20 @@ void __pascal far check_fall_flo() {
 // seg000:1051
 void __pascal far read_joyst_control() {
 	// stub
+	if (joy_states[0] == -1) 
+		control_x = -1;
+	
+	if (joy_states[0] == 1)
+		control_x = 1;
+
+	if (joy_states[1] == -1)
+		control_y = -1;
+
+	if (joy_states[1] == 1)
+		control_y = 1;
+
+	if (joy_states[2])
+		control_shift = -1;
 }
 
 // seg000:10EA

--- a/seg009.c
+++ b/seg009.c
@@ -1754,11 +1754,16 @@ void __pascal far set_gr_mode(byte grmode) {
 	Uint32 flags = 0;
 	int fullscreen = check_param("full") != 0;
 	if (fullscreen) flags |= SDL_WINDOW_FULLSCREEN;
+	else			flags |= SDL_WINDOW_RESIZABLE;
+	
 	window_ = SDL_CreateWindow(WINDOW_TITLE,
 										  SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
 										  POP_WINDOW_WIDTH, POP_WINDOW_HEIGHT, flags);
 	renderer_ = SDL_CreateRenderer(window_, -1 , 0);
     SDL_RenderPresent(renderer_); // this simply draws a black screen
+	
+	// Allow us to use a consistent set of screen co-ordinates, even if the screen size changes
+	SDL_RenderSetLogicalSize(renderer_, POP_WINDOW_WIDTH, POP_WINDOW_HEIGHT);
 
     /* Migration to SDL2: everything is still blitted to onscreen_surface_, however:
      * SDL2 renders textures to the screen instead of surfaces; so for now, every screen


### PR DESCRIPTION
This is a rather basic implementation of Joystick support, it was impossible to match the disassembly... due to the fact 'read_joyst_control' reads the port from the motherboard, so it was 'kind of simulated' :) via 'joy_states[3]' variable