### PR TITLE
Fix unable to enter exit door in level 4

### DIFF
--- a/seg005.c
+++ b/seg005.c
@@ -290,7 +290,7 @@ void __pascal far up_pressed() {
 	else if (get_tile_infrontof_char() == tiles_16_level_door_left) leveldoor_tilepos = curr_tilepos;
 	if ((leveldoor_tilepos != -1) &&
 		level.start_room != drawn_room &&
-		curr_room_modif[leveldoor_tilepos] >= 43 // this door must be fully open
+		curr_room_modif[leveldoor_tilepos] >= 42 // this door must be fully open
 	){
 		go_up_leveldoor();
 	} else {


### PR DESCRIPTION
Apparently the level door modifier does not always reach 43 when it is opened. Lowered the threshold to 42.

I committed this earlier in my mod branch but forgot to check whether the bug also occurred in the original levels (thanks, @NagyD).