### PR TITLE
Quicksave: remaining time & compatibility check

### DIFF
--- a/config.h
+++ b/config.h
@@ -53,6 +53,9 @@ The authors of this program may be contacted at http://forum.princed.org
 // Enable quicksave/load feature.
 #define USE_QUICKSAVE
 
+// Enable one-minute penalty for quickloading
+#define USE_QUICKLOAD_PENALTY
+
 // Bugfixes:
 
 // The mentioned tricks can be found here: http://www.popot.org/documentation.php?doc=Tricks


### PR DESCRIPTION
Quickloading is cancelled when a version string saved in QUICKSAVE.SAV does not match.
Added rem_min and rem_tick to the quicksaved variables. The proposed penalty for quickloading is one minute subtracted from the saved remaining time.