### PR TITLE
Increase the number of supported potion types to 32

### DIFF
--- a/seg005.c
+++ b/seg005.c
@@ -454,7 +454,7 @@ void __pascal far get_item() {
 		do_pickup(-1);
 		seqtbl_offset_char(seq_91_get_sword); // get sword
 	} else { // potion
-		do_pickup(curr_room_modif[curr_tilepos] >> 5);
+		do_pickup(curr_room_modif[curr_tilepos] >> 3);
 		seqtbl_offset_char(seq_78_drink); // drink
 #ifdef USE_COPYPROT
 		if (current_level == 15) {

--- a/seg007.c
+++ b/seg007.c
@@ -256,8 +256,8 @@ void __pascal far animate_torch() {
 void __pascal far animate_potion() {
 	word type;
 	if (trob.type >= 0 && is_trob_in_drawn_room()) {
-		type = curr_modifier & 0xE0;
-		curr_modifier = bubble_next_frame(curr_modifier & 0x1F) | type;
+		type = curr_modifier & 0xF8;
+		curr_modifier = bubble_next_frame(curr_modifier & 0x07) | type;
 		set_redraw_anim_curr();
 	}
 }
@@ -564,7 +564,7 @@ void __pascal far start_anim_torch(short room,short tilepos) {
 
 // seg007:0847
 void __pascal far start_anim_potion(short room,short tilepos) {
-	curr_room_modif[tilepos] &= 0xE0;
+	curr_room_modif[tilepos] &= 0xF8;
 	curr_room_modif[tilepos] |= prandom(6) + 1;
 	add_trob(room, tilepos, 1);
 }

--- a/seg008.c
+++ b/seg008.c
@@ -530,23 +530,23 @@ void __pascal far draw_tile_anim() {
 			ptr_add_table(id_chtab_6_environment, spikes_fram_left[get_spike_frame(curr_modifier)], draw_xh, 0, draw_main_y - 2, blitters_10h_transp, 0);
 			break;
 		case tiles_10_potion:
-			switch (curr_modifier & 0xE0) {
-				case 0x00: // empty
-					return;
-				case 0xA0: // hurt
-				case 0xC0: // open
+			switch((curr_modifier & 0xF8) >> 3) {
+				case 0:
+					return; //empty
+				case 5: // hurt
+				case 6: // open
 					color = 9; // blue
 					break;
-				case 0x60: // slow fall
-				case 0x80: // upside down
+				case 3: // slow fall
+				case 4: // upside down
 					color = 10; // green
 					// fallthrough!
-				case 0x40: // life
+				case 2: // life
 					pot_size = 1;
 					break;
 			}
 			add_backtable(id_chtab_1_flameswordpotion, 23 /*bubble mask*/, draw_xh + 3, 1, draw_main_y - (pot_size << 2) - 14, blitters_40h_mono, 0);
-			add_foretable(id_chtab_1_flameswordpotion, potion_fram_bubb[curr_modifier & 0xF], draw_xh + 3, 1, draw_main_y - (pot_size << 2) - 14, color + blitters_40h_mono, 0);
+			add_foretable(id_chtab_1_flameswordpotion, potion_fram_bubb[curr_modifier & 0x7], draw_xh + 3, 1, draw_main_y - (pot_size << 2) - 14, color + blitters_40h_mono, 0);
 			break;
 		case tiles_22_sword:
 			add_midtable(id_chtab_1_flameswordpotion, (curr_modifier == 1) + 10, draw_xh, 0, draw_main_y - 3, blitters_10h_transp, curr_modifier == 1);
@@ -570,7 +570,7 @@ const byte wall_fram_main[] = {8, 10, 6, 4};
 void __pascal far draw_tile_fore() {
 	word ybottom;
 	byte xh;
-	word var_6;
+	word potion_type;
 	word id;
 	word var_2;
 	if (tile_left == tiles_4_gate && Kid.curr_row == drawn_row && Kid.curr_col == drawn_col - 1 && Kid.room != room_R) {
@@ -599,8 +599,9 @@ void __pascal far draw_tile_fore() {
 			id = tile_table[curr_tile].fore_id;
 			if (id == 0) return;
 			if (curr_tile == tiles_10_potion) {
-				var_6 = curr_modifier & 0xE0;
-				if (var_6 < 0xA0 && var_6 >= 0x40) id = 13;
+				// large pots are drawn for potion types 2, 3, 4
+				potion_type = (curr_modifier & 0xF8) >> 3;
+				if (potion_type < 5 && potion_type >= 2) id = 13; // small pot = 12, large pot = 13
 			}
 			xh = tile_table[curr_tile].fore_x + draw_xh;
 			ybottom = tile_table[curr_tile].fore_y + draw_main_y;
@@ -1041,7 +1042,7 @@ void __pascal far load_alter_mod(int tilepos) {
 			*curr_tile_modif = 0;
 			break;
 		case tiles_10_potion:
-			*curr_tile_modif <<= 5;
+			*curr_tile_modif <<= 3;
 #ifdef USE_COPYPROT
 			if (current_level == 15) {
 				// Copy protection


### PR DESCRIPTION
This change makes 2 originally unused bits available for potion types, thereby increasing the maximum number of unique potions from 8 to 32.
The original game reserves 5 bits of the tile modifier byte for the frames of the potion bubble animation; the remaining (most significant) 3 bits are used for the potion types. However, the potion animation has only 7 frames so 3 bits is quite sufficient for the bubble animation.