### PR TITLE
Fix bug with loose tiles to the left of potions

### DIFF
--- a/seg008.c
+++ b/seg008.c
@@ -242,13 +242,18 @@ int __pascal far get_tile_to_draw(int room, int column, int row, byte *ptr_tilet
 		*ptr_tiletype = tile_room0;
 	}
 	// Is this a pressed button?
-	if (*ptr_tiletype == tiles_6_closer) {
+	byte tiletype = *ptr_tiletype;
+	if (tiletype == tiles_6_closer) {
 		if (get_doorlink_timer(*ptr_modifier) > 1) {
 			*ptr_tiletype = tiles_5_stuck;
 		}
-	} else if (*ptr_tiletype == tiles_15_opener) {
+	} else if (tiletype == tiles_15_opener) {
 		if (get_doorlink_timer(*ptr_modifier) > 1) {
 			*ptr_modifier = 0;
+			*ptr_tiletype = tiles_1_floor;
+		}
+	} else if (tiletype == tiles_11_loose) {
+		if (*ptr_modifier == 0) {
 			*ptr_tiletype = tiles_1_floor;
 		}
 	}


### PR DESCRIPTION
A drawing bug occurs when a loose tile is placed to the left of a potion.
The right side of the loose tile is drawn as if it is an edge instead of part of a continuous floor.

This is an attempted fix. Unfortunately, the bug still occurs when the loose tile wobbles. I am not sure how this could be fixed.