### PR TITLE
Various small improvements

### DIFF
--- a/config.h
+++ b/config.h
@@ -60,6 +60,9 @@ The authors of this program may be contacted at http://forum.princed.org
 // Enable one-minute penalty for quickloading
 #define USE_QUICKLOAD_PENALTY
 
+// Time passes while the level ending music plays; however, this can be skipped by disabling sound.
+// This disables time passing while the ending music is playing, so you can leave sounds on.
+#define DISABLE_TIME_DURING_END_MUSIC
 
 // Bugfixes:
 

--- a/config.h
+++ b/config.h
@@ -111,6 +111,10 @@ The authors of this program may be contacted at http://forum.princed.org
 // Controls do not get released properly when drinking a potion, sometimes causing unintended movements.
 #define FIX_MOVE_AFTER_DRINK
 
+// Guards may "follow" the kid to the room on the left, even though there is a closed gate in between.
+#define FIX_GUARD_FOLLOWING_THROUGH_CLOSED_GATES
+
+
 // Debug features:
 
 // When the program starts, check whether the deobfuscated sequence table (seqtbl.c) is correct.

--- a/config.h
+++ b/config.h
@@ -123,4 +123,9 @@ The authors of this program may be contacted at http://forum.princed.org
 // When the program starts, check whether the deobfuscated sequence table (seqtbl.c) is correct.
 //#define CHECK_SEQTABLE_MATCHES_ORIGINAL
 
+// Enable debug cheats
+// "[" and "]" : nudge x position by one pixel
+// "T" : display remaining time in minutes, seconds and ticks
+//#define USE_DEBUG_CHEATS
+
 #endif

--- a/seg000.c
+++ b/seg000.c
@@ -561,6 +561,14 @@ int __pascal far process_key() {
 				flash_time = 4;
 				add_life();
 			break;
+			#ifdef USE_DEBUG_CHEATS
+			case SDL_SCANCODE_T:
+				printf("Remaining minutes: %d\tticks:%d\n", rem_min, rem_tick);
+				snprintf(sprintf_temp, sizeof(sprintf_temp), "M:%d S:%d T:%d", rem_min, rem_tick / 12, rem_tick);
+				answer_text = sprintf_temp;
+				need_show_text = 1;
+			break;
+			#endif
 		}
 	}
 
@@ -1192,6 +1200,13 @@ void __pascal far read_keyb_control() {
 		control_x = 1;
 	}
 	control_shift = -(key_states[SDL_SCANCODE_LSHIFT] || key_states[SDL_SCANCODE_RSHIFT]);
+
+	#ifdef USE_DEBUG_CHEATS
+	if (cheats_enabled) {
+		if (key_states[SDL_SCANCODE_RIGHTBRACKET]) ++Char.x;
+		else if (key_states[SDL_SCANCODE_LEFTBRACKET]) --Char.x;
+	}
+	#endif
 }
 
 // seg000:156D

--- a/seg000.c
+++ b/seg000.c
@@ -322,7 +322,7 @@ int need_quick_load = 0;
 
 void check_quick_op() {
 	if (need_quick_save) {
-		if (quick_save()) {
+		if (!is_feather_fall && quick_save()) {
 			display_text_bottom("QUICKSAVE");
 		} else {
 			display_text_bottom("NO QUICKSAVE");
@@ -364,6 +364,9 @@ int __pascal far process_key() {
 
 	if (start_level == 0) {
 		if (key || control_shift) {
+			#ifdef USE_QUICKSAVE
+			if (key == SDL_SCANCODE_F9) need_quick_load = 1;
+			#endif
 			if (key == (SDL_SCANCODE_L | WITH_CTRL)) { // ctrl-L
 				if (!load_game()) return 0;
 			} else {
@@ -473,9 +476,11 @@ int __pascal far process_key() {
 		break;
 #ifdef USE_QUICKSAVE
 		case SDL_SCANCODE_F6:
-			need_quick_save = 1;
+		case SDL_SCANCODE_F6 | WITH_SHIFT:
+			if (Kid.alive < 0) need_quick_save = 1;
 		break;
 		case SDL_SCANCODE_F9:
+		case SDL_SCANCODE_F9 | WITH_SHIFT:
 			need_quick_load = 1;
 		break;
 #endif // USE_QUICKSAVE

--- a/seg002.c
+++ b/seg002.c
@@ -254,6 +254,13 @@ void __pascal far exit_room() {
 			if (roomleave_result == 0) {
 				// left
 				if (Guard.x >= 91) leave = 1;
+				#ifdef FIX_GUARD_FOLLOWING_THROUGH_CLOSED_GATES
+				else if (Guard.x > 0) {
+					get_tile(Kid.room, Kid.curr_row * 10 + 9, Kid.curr_row);
+					if (curr_tile == tiles_4_gate && can_bump_into_gate())
+							leave = 1;
+				}
+				#endif
 			} else if (roomleave_result == 1) {
 				// right
 				if (Guard.x < 165) leave = 1;

--- a/seg008.c
+++ b/seg008.c
@@ -1510,6 +1510,9 @@ void __pascal far show_time() {
 	char sprintf_temp[40];
 	word rem_sec;
 	if (Kid.alive < 0 &&
+		#ifdef DISABLE_TIME_DURING_END_MUSIC
+		next_level == current_level &&
+		#endif
 		rem_min != 0 &&
 		(current_level < 13 || (current_level == 13 && leveldoor_open == 0)) &&
 		current_level < 15

--- a/seqtbl.c
+++ b/seqtbl.c
@@ -36,7 +36,9 @@ The authors of this program may be contacted at http://forum.princed.org
 #define set_fall(x, y) SEQ_SET_FALL, (byte) x, (byte) y
 
 // This splits the byte array into labeled "sections" that are packed tightly next to each other
-#define LABEL(label) }; const byte label##_eventual_ptr[] __attribute__ ((aligned(1))) = {
+// However, it only seems to work correctly in the Debug configuration...
+//#define LABEL(label) }; const byte label##_eventual_ptr[] __attribute__ ((aligned(1))) = {
+#define LABEL(label) // disable
 //#define OFFSET(label) label - seqtbl + SEQTBL_BASE
 
 // Labels


### PR DESCRIPTION
**Fix guards following through closed gates**
Guards may "follow" the kid to the room on the left, even though there is a closed gate in between.
The fix attempts to check first that the guard can actually move through the gate.

**Freeze time during the end level music**
Normally, time passes while the level ending music plays; however, the music can be skipped by disabling sound.
This optional change disables time passing while the ending music plays, so you can leave sound on.

**Add option for debug cheats**
This adds a few cheats that are useful for testing purposes:
- The square brackets ] and [ nudge the X position of the kid, to help align him perfectly
- After pressing T, the exact remaining time in minutes, seconds and ticks is displayed

**Improve user-friendliness of quicksaving**
- Also quicksave/quickload when shift is pressed
- Do not even attempt to quicksave after the kid has died
- Deny quicksave during the feather fall effect
- Allow quickloading from the title screen

**Fix seqtbl not compiling correctly in release mode**
Disabled the LABEL macro because apparently the sections do get moved around...