### PR TITLE
New feature: view/record replays

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SOURCE_FILES
     seg007.c
     seg008.c
     seg009.c
+    replay.c
     seqtbl.c
     types.h
 )

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CC = gcc
 RM = rm -f
 
 HFILES = common.h config.h data.h proto.h types.h
-OBJ = main.o data.o seg000.o seg001.o seg002.o seg003.o seg004.o seg005.o seg006.o seg007.o seg008.o seg009.o seqtbl.o
+OBJ = main.o data.o seg000.o seg001.o seg002.o seg003.o seg004.o seg005.o seg006.o seg007.o seg008.o seg009.o seqtbl.o replay.c
 BIN = prince
 
 LIBS := $(shell pkg-config --libs   sdl2 SDL2_image SDL2_mixer)

--- a/config.h
+++ b/config.h
@@ -64,6 +64,9 @@ The authors of this program may be contacted at http://forum.princed.org
 // This disables time passing while the ending music is playing, so you can leave sounds on.
 //#define DISABLE_TIME_DURING_END_MUSIC
 
+// Enable recording/replay feature.
+#define USE_REPLAY
+
 // Bugfixes:
 
 // The mentioned tricks can be found here: http://www.popot.org/documentation.php?doc=Tricks

--- a/data.h
+++ b/data.h
@@ -559,6 +559,7 @@ word last_loose_sound;
 byte recording INIT(= 0);
 byte replaying INIT(= 0);
 dword num_replay_ticks INIT(= 0);
+byte need_replay_cycle INIT(= 0);
 #endif // USE_REPLAY
 
 #undef INIT

--- a/data.h
+++ b/data.h
@@ -555,6 +555,11 @@ word word_1E1AA;
 // data:5F84
 word last_loose_sound;
 
+#ifdef USE_REPLAY
+byte recording INIT(= 0);
+byte replaying INIT(= 0);
+dword num_replay_ticks INIT(= 0);
+#endif // USE_REPLAY
 
 #undef INIT
 #undef extern

--- a/proto.h
+++ b/proto.h
@@ -607,7 +607,8 @@ void stop_recording();
 void start_replay();
 void do_replay_move();
 void save_recorded_replay();
-void load_recorded_replay();
+void replay_cycle();
+void load_replay();
 void key_press_while_recording(int* key_ptr);
 void key_press_while_replaying(int* key_ptr);
 #endif

--- a/proto.h
+++ b/proto.h
@@ -72,6 +72,7 @@ void __pascal far show_loading();
 void __pascal far show_quotes();
 #ifdef USE_QUICKSAVE
 void check_quick_op();
+void restore_room_after_quick_load();
 #endif // USE_QUICKSAVE
 
 // SEG001.C
@@ -593,4 +594,20 @@ void free_sound(sound_buffer_type far *buffer);
 // SEQTABLE.C
 #ifdef CHECK_SEQTABLE_MATCHES_ORIGINAL
 void check_seqtable_matches_original();
+#endif
+
+// REPLAY.C
+#ifdef USE_REPLAY
+void init_record_replay();
+void replay_restore_level();
+int restore_savestate_from_buffer();
+void start_recording();
+void add_replay_move();
+void stop_recording();
+void start_replay();
+void do_replay_move();
+void save_recorded_replay();
+void load_recorded_replay();
+void key_press_while_recording(int* key_ptr);
+void key_press_while_replaying(int* key_ptr);
 #endif

--- a/replay.c
+++ b/replay.c
@@ -1,0 +1,266 @@
+/*
+SDLPoP, a port/conversion of the DOS game Prince of Persia.
+Copyright (C) 2013-2015  Dávid Nagy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+The authors of this program may be contacted at http://forum.princed.org
+*/
+
+#include "common.h"
+
+#ifdef USE_REPLAY
+
+#define MAX_REPLAY_DURATION 345600 // 8 hours: 720 * 60 * 8 ticks
+byte moves[MAX_REPLAY_DURATION] = {0}; // static memory for now because it is easier (should this be dynamic?)
+
+enum special_moves {
+    MOVE_RESTART_LEVEL = 1,
+};
+
+// 1-byte structure representing which controls were active at a particular game tick
+typedef union replay_move {
+    struct {
+        sbyte x : 2;
+        sbyte y : 2;
+        byte shift : 1;
+        byte special : 3;
+    };
+    byte bits;
+} replay_move;
+
+dword curr_tick = 0;
+dword saved_random_seed;
+byte special_move = 0;
+
+FILE* replay_fp;
+const char* const replay_file = "REPLAY.SAV";
+
+byte* savestate_buffer = NULL;
+size_t savestate_offset = 0;
+size_t savestate_size = 0;
+#define MAX_SAVESTATE_SIZE 4096
+
+// These are defined in seg000.c:
+typedef int process_func_type(void* data, size_t data_size);
+extern int quick_process(process_func_type process_func);
+extern const char const quick_version[];
+extern char quick_control[];
+
+void init_record_replay() {
+    if (check_param("record")) {
+        start_recording();
+    }
+    else if (check_param("replay")) {
+        start_replay();
+    }
+}
+
+void replay_restore_level() {
+    // Need to restore the savestate at the right time (just before the first room of the level is drawn).
+    // Otherwise, for "on-the-fly" recordings, the screen will visibly "jump" to the replay savestate.
+    // This only needs to happen at the very beginning of the replay (curr_tick == 0)
+    if (curr_tick == 0) restore_savestate_from_buffer();
+}
+
+int process_to_buffer(void* data, size_t data_size) {
+    if (savestate_offset + data_size > MAX_SAVESTATE_SIZE) {
+        printf("Saving savestate to memory failed: buffer is overflowing!\n");
+        return 0;
+    }
+    memcpy(savestate_buffer + savestate_offset, data, data_size);
+    savestate_offset += data_size;
+    return 1;
+}
+
+int process_load_from_buffer(void* data, size_t data_size) {
+    memcpy(data, savestate_buffer + savestate_offset, data_size);
+    savestate_offset += data_size;
+    return 1;
+}
+
+int savestate_to_buffer() {
+    int ok = 0;
+    if (savestate_buffer == NULL)
+        savestate_buffer = malloc(MAX_SAVESTATE_SIZE);
+    if (savestate_buffer != NULL) {
+        savestate_offset = 0;
+        savestate_size = 0;
+        ok = quick_process(process_to_buffer);
+        savestate_size = savestate_offset;
+    }
+    return ok;
+}
+
+
+int restore_savestate_from_buffer() {
+    int ok = 0;
+    savestate_offset = 0;
+    while (savestate_offset < savestate_size) {
+        ok = quick_process(process_load_from_buffer);
+    }
+    restore_room_after_quick_load();
+    return ok;
+}
+
+void start_recording() {
+    curr_tick = 0;
+    recording = 1; // further set-up is done in add_replay_move, on the first gameplay tick
+}
+
+void add_replay_move() {
+    if (curr_tick == 0) {
+        prandom(1); // make sure random_seed is initialized
+        saved_random_seed = random_seed;
+        seed_was_init = 1;
+        savestate_to_buffer(); // create a savestate in memory
+        display_text_bottom("RECORDING");
+        text_time_total = 24;
+        text_time_remaining = 24;
+    }
+
+    replay_move curr_move = {0};
+    curr_move.x = control_x;
+    curr_move.y = control_y;
+    if (control_shift) curr_move.shift = 1;
+
+    if (special_move)  {
+        curr_move.special = special_move;
+        special_move = 0;
+    }
+
+    moves[curr_tick] = curr_move.bits;
+
+    ++curr_tick;
+
+    if (curr_tick >= MAX_REPLAY_DURATION) { // max replay length exceeded
+        stop_recording();
+    }
+}
+
+void stop_recording() {
+    save_recorded_replay();
+    recording = 0;
+    display_text_bottom("REPLAY SAVED");
+    text_time_total = 24;
+    text_time_remaining = 24;
+}
+
+void start_replay() {
+    replaying = 1;
+    curr_tick = 0;
+    load_recorded_replay();
+}
+
+void do_replay_move() {
+    if (curr_tick == 0) {
+        random_seed = saved_random_seed;
+        seed_was_init = 1;
+    }
+    if (curr_tick == num_replay_ticks) { // recording is finished
+        replaying = 0;
+        start_level = 0;
+        start_game();
+    }
+
+    replay_move curr_move;
+    curr_move.bits = moves[curr_tick];
+
+    control_x = curr_move.x;
+    control_y = curr_move.y;
+    control_shift = (curr_move.shift) ? -1 : 0;
+
+    if (curr_move.special == MOVE_RESTART_LEVEL) { // restart level
+        stop_sounds();
+        is_restart_level = 1;
+    }
+
+//    if (curr_tick > 5 ) printf("rem_tick: %d\t curr_tick: %d\tlast 5 moves: %d, %d, %d, %d, %d\n", rem_tick, curr_tick,
+//                               moves[curr_tick-4], moves[curr_tick-3], moves[curr_tick-2], moves[curr_tick-1], moves[curr_tick]);
+    ++curr_tick;
+}
+
+void save_recorded_replay() {
+    replay_fp = fopen(replay_file, "wb");
+    if (replay_fp != NULL) {
+        // embed a savestate into the replay
+        fwrite(&savestate_size, sizeof(savestate_size), 1, replay_fp);
+        fwrite(savestate_buffer, savestate_size, 1, replay_fp);
+        // save the rest of the replay data
+        num_replay_ticks = curr_tick;
+        fwrite(&start_level, sizeof(start_level), 1, replay_fp);
+        fwrite(&saved_random_seed, sizeof(saved_random_seed), 1, replay_fp);
+        fwrite(&num_replay_ticks, sizeof(num_replay_ticks), 1, replay_fp);
+        fwrite(moves, num_replay_ticks, 1, replay_fp);
+        fclose(replay_fp);
+    }
+}
+
+void load_recorded_replay() {
+    replay_fp = fopen(replay_file, "rb");
+    if (savestate_buffer == NULL)
+        savestate_buffer = malloc(MAX_SAVESTATE_SIZE);
+    if (replay_fp != NULL && savestate_buffer != NULL) {
+        // load the savestate
+        fread(&savestate_size, sizeof(savestate_size), 1, replay_fp);
+        fread(savestate_buffer, savestate_size, 1, replay_fp);
+        // load the rest of the replay data
+        fread(&start_level, sizeof(start_level), 1, replay_fp);
+        fread(&saved_random_seed, sizeof(saved_random_seed), 1, replay_fp);
+        fread(&num_replay_ticks, sizeof(num_replay_ticks), 1, replay_fp);
+        fread(moves, num_replay_ticks, 1, replay_fp);
+        fclose(replay_fp);
+    }
+}
+
+void key_press_while_recording(int* key_ptr) {
+    int key = *key_ptr;
+    switch(key) {
+        case SDL_SCANCODE_A | WITH_CTRL:
+            special_move = MOVE_RESTART_LEVEL;
+            break;
+        case SDL_SCANCODE_R | WITH_CTRL:
+            save_recorded_replay();
+            recording = 0;
+        default:
+            break;
+    }
+}
+
+void key_press_while_replaying(int* key_ptr) {
+    int key = *key_ptr;
+    switch(key) {
+        default:
+            // cannot manually do most stuff during a replay!
+            *key_ptr = 0;
+            break;
+        // but these are allowable actions:
+        case SDL_SCANCODE_ESCAPE:               // pause
+        case SDL_SCANCODE_ESCAPE | WITH_SHIFT:
+        case SDL_SCANCODE_SPACE:                // time
+        case SDL_SCANCODE_S | WITH_CTRL:        // sound toggle
+        case SDL_SCANCODE_V | WITH_CTRL:        // version
+        case SDL_SCANCODE_C:                    // room numbers
+        case SDL_SCANCODE_C | WITH_SHIFT:
+        case SDL_SCANCODE_I | WITH_SHIFT:       // invert
+        case SDL_SCANCODE_B | WITH_SHIFT:       // blind
+        case SDL_SCANCODE_T:                    // debug time
+            break;
+        case SDL_SCANCODE_R | WITH_CTRL:        // restart game
+            replaying = 0;
+            break;
+    }
+}
+
+#endif // USE_REPLAY

--- a/seg000.c
+++ b/seg000.c
@@ -238,12 +238,26 @@ int quick_process(process_func_type process_func) {
 	// remaining time
 	process(rem_min);
 	process(rem_tick);
+	// saved controls
+	process(control_x);
+	process(control_y);
+	process(control_shift);
+	process(control_forward);
+	process(control_backward);
+	process(control_up);
+	process(control_down);
+	process(control_shift2);
+	process(ctrl1_forward);
+	process(ctrl1_backward);
+	process(ctrl1_up);
+	process(ctrl1_down);
+	process(ctrl1_shift2);
 #undef process
 	return ok;
 }
 
 const char* const quick_file = "QUICKSAVE.SAV";
-const char const quick_version[] = "V1.16   ";
+const char const quick_version[] = "V1.16b3 ";
 char quick_control[] = "........";
 
 int quick_save() {
@@ -276,9 +290,7 @@ void restore_room_after_quick_load() {
 
 	hitp_delta = guardhp_delta = 1; // force HP redraw
 	draw_hp();
-
-	// Kid should not move immediately after quickload
-	clear_saved_ctrl();
+	loadkid_and_opp();
 	// Get rid of "press button" message if kid was dead before quickload.
 	text_time_total = text_time_remaining = 0;
 	//next_sound = current_sound = -1;

--- a/seg000.c
+++ b/seg000.c
@@ -96,6 +96,9 @@ void __pascal far init_game_main() {
 	load_opt_sounds(43, 56); //added
 	hof_read();
 
+#ifdef USE_REPLAY
+	init_record_replay();
+#endif
 	start_game();
 }
 
@@ -255,6 +258,33 @@ int quick_save() {
 	return ok;
 }
 
+void restore_room_after_quick_load() {
+	int temp1 = curr_guard_color;
+	int temp2 = next_level;
+	load_lev_spr(current_level);
+	curr_guard_color = temp1;
+	next_level = temp2;
+
+	//need_full_redraw = 1;
+	different_room = 1;
+	next_room = drawn_room;
+	load_room_links();
+	//draw_level_first();
+	//gen_palace_wall_colors();
+	draw_game_frame(); // for falling
+	//redraw_screen(1); // for room_L
+
+	hitp_delta = guardhp_delta = 1; // force HP redraw
+	draw_hp();
+
+	// Kid should not move immediately after quickload
+	clear_saved_ctrl();
+	// Get rid of "press button" message if kid was dead before quickload.
+	text_time_total = text_time_remaining = 0;
+	//next_sound = current_sound = -1;
+	exit_room_timer = 0;
+}
+
 int quick_load() {
 
 	int ok = 0;
@@ -279,34 +309,11 @@ int quick_load() {
 		fclose(quick_fp);
 		quick_fp = NULL;
 
-		int temp1 = curr_guard_color;
-		int temp2 = next_level;
-		load_lev_spr(current_level);
-		curr_guard_color = temp1;
-		next_level = temp2;
-
-		//need_full_redraw = 1;
-		different_room = 1;
-		next_room = drawn_room;
-		load_room_links();
-		//draw_level_first();
-		//gen_palace_wall_colors();
-		draw_game_frame(); // for falling
-		//redraw_screen(1); // for room_L
-
-		hitp_delta = guardhp_delta = 1; // force HP redraw
-		draw_hp();
+		restore_room_after_quick_load();
 
 		do_wait(timer_0);
 		screen_updates_suspended = 0;
 		request_screen_update();
-
-		// Kid should not move immediately after quickload
-		clear_saved_ctrl();
-		// Get rid of "press button" message if kid was dead before quickload.
-		text_time_total = text_time_remaining = 0;
-		//next_sound = current_sound = -1;
-		exit_room_timer = 0;
 
 		#ifdef USE_QUICKLOAD_PENALTY
 		// Subtract one minute from the remaining time (if it is above 5 minutes)
@@ -367,6 +374,12 @@ int __pascal far process_key() {
 			#ifdef USE_QUICKSAVE
 			if (key == SDL_SCANCODE_F9) need_quick_load = 1;
 			#endif
+			#ifdef USE_REPLAY
+			if (key == SDL_SCANCODE_TAB) {
+				start_replay();
+			}
+			else
+			#endif
 			if (key == (SDL_SCANCODE_L | WITH_CTRL)) { // ctrl-L
 				if (!load_game()) return 0;
 			} else {
@@ -386,6 +399,10 @@ int __pascal far process_key() {
 	if (rem_min != 0 && Kid.alive > 6 && (control_shift || key == SDL_SCANCODE_RETURN)) {
 		key = SDL_SCANCODE_A | WITH_CTRL; // ctrl-a
 	}
+#ifdef USE_REPLAY
+	if (recording) key_press_while_recording(&key);
+	else if (replaying) key_press_while_replaying(&key);
+#endif
 	if (key == 0) return 0;
 	if (is_keyboard_mode) clear_kbd_buf();
 
@@ -483,6 +500,17 @@ int __pascal far process_key() {
 		case SDL_SCANCODE_F9 | WITH_SHIFT:
 			need_quick_load = 1;
 		break;
+#ifdef USE_REPLAY
+		case SDL_SCANCODE_TAB | WITH_CTRL:
+		case SDL_SCANCODE_TAB | WITH_CTRL | WITH_SHIFT:
+			if (recording) { // finished recording
+				stop_recording();
+			}
+			else { // should start recording
+				start_recording();
+			}
+			break;
+#endif // USE_RECORD_REPLAY
 #endif // USE_QUICKSAVE
 	}
 	if (cheats_enabled) {

--- a/seg003.c
+++ b/seg003.c
@@ -86,7 +86,13 @@ void __pascal far play_level(int level) {
 				quit(1);
 			}
 			cutscene_func = tbl_cutscenes[level];
-			if (cutscene_func != NULL) {
+			if (cutscene_func != NULL
+
+				#ifdef USE_REPLAY
+				&& !(recording || replaying)
+				#endif
+
+					) {
 				load_intro(level > 2, cutscene_func, 1);
 			}
 		}
@@ -119,6 +125,9 @@ void __pascal far play_level(int level) {
 		// busy waiting?
 		while (check_sound_playing() && !do_paused()) idle();
 		stop_sounds();
+		#ifdef USE_REPLAY
+		if (replaying) replay_restore_level();
+		#endif
 		draw_level_first();
 		show_copyprot(0);
 		level = play_level_2();

--- a/seg003.c
+++ b/seg003.c
@@ -315,6 +315,11 @@ int __pascal far play_level_2() {
 #ifdef USE_QUICKSAVE
 		check_quick_op();
 #endif // USE_QUICKSAVE
+
+#ifdef USE_REPLAY
+		if (need_replay_cycle) replay_cycle();
+#endif // USE_QUICKSAVE
+
 		if (Kid.sword == sword_2_drawn) {
 			// speed when fighting (smaller is faster)
 			start_timer(timer_1, 6);

--- a/seg006.c
+++ b/seg006.c
@@ -1202,6 +1202,10 @@ void __pascal far control_kid() {
 	} else {
 		rest_ctrl_1();
 		do_paused();
+		#ifdef USE_REPLAY
+		if (recording) add_replay_move();
+		if (replaying) do_replay_move();
+		#endif
 		read_user_control();
 		user_control();
 		save_ctrl_1();

--- a/seg009.c
+++ b/seg009.c
@@ -86,6 +86,11 @@ int __pascal far key_test_quit() {
 	word key;
 	key = read_key();
 	if (key == (SDL_SCANCODE_Q | WITH_CTRL)) { // ctrl-q
+
+		#ifdef USE_REPLAY
+		if (recording) save_recorded_replay();
+		#endif
+
 		quit(0);
 	}
 	return key;


### PR DESCRIPTION
This adds a way to capture and view replays in SDLPoP.

To start recording, you can use the command line parameter "record". You can also start/stop recording on the fly using the shortcut Ctrl+Tab.
For now, replays get saved as "REPLAY.SAV".
To view a previously saved replay, use the command line parameter "replay" or press Tab on the title screen.

This adds a new source file: replay.c (has been added to the Linux makefile).
The feature needs quicksave to be enabled because savestates get embedded into the replay files.