### PR TITLE
Configurable options using an INI file + bug fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(SDLPoP)
 
 # Use C++11 when using the C++ compiler
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 
 if (WIN32)
     # Use the -mwindows compiler flag when compiling with MinGW to hide the console window
@@ -40,15 +40,16 @@ set(SOURCE_FILES
     seg007.c
     seg008.c
     seg009.c
-    replay.c
     seqtbl.c
+    options.c
+    replay.c
     types.h
 )
-add_executable(SDLPoP ${SOURCE_FILES})
+add_executable(prince ${SOURCE_FILES})
 
 # @Todo: add a configuration for Mac OS X
 
-target_link_libraries(SDLPoP mingw32 SDL2main SDL2 SDL2.dll SDL2_image SDL2_mixer)
+target_link_libraries(prince mingw32 SDL2main SDL2 SDL2.dll SDL2_image SDL2_mixer)
 
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SOURCE_FILES
     seg007.c
     seg008.c
     seg009.c
+    replay.c
     seqtbl.c
     types.h
 )

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CC = gcc
 RM = rm -f
 
 HFILES = common.h config.h data.h proto.h types.h
-OBJ = main.o data.o seg000.o seg001.o seg002.o seg003.o seg004.o seg005.o seg006.o seg007.o seg008.o seg009.o seqtbl.o replay.c
+OBJ = main.o data.o seg000.o seg001.o seg002.o seg003.o seg004.o seg005.o seg006.o seg007.o seg008.o seg009.o seqtbl.o replay.o options.o
 BIN = prince
 
 LIBS := $(shell pkg-config --libs   sdl2 SDL2_image SDL2_mixer)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CC = gcc
 RM = rm -f
 
 HFILES = common.h config.h data.h proto.h types.h
-OBJ = main.o data.o seg000.o seg001.o seg002.o seg003.o seg004.o seg005.o seg006.o seg007.o seg008.o seg009.o seqtbl.o
+OBJ = main.o data.o seg000.o seg001.o seg002.o seg003.o seg004.o seg005.o seg006.o seg007.o seg008.o seg009.o seqtbl.o replay.c
 BIN = prince
 
 LIBS := $(shell pkg-config --libs   sdl2 SDL2_image SDL2_mixer)

--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -1,0 +1,32 @@
+; ====================
+; SDLPoP configuration
+; ====================
+
+disable_all_fixes = false
+enable_copyprot = false
+enable_mixer = true
+enable_fade = true
+enable_flash = true
+enable_text = true
+enable_quicksave = true
+enable_quicksave_penalty = true
+enable_replay = true
+enable_crouch_after_climbing = true
+enable_freeze_time_during_end_music = true
+fix_gate_sounds = true
+fix_two_coll_bug = true
+fix_infinite_down_bug = true
+fix_gate_drawing_bug = false
+fix_bigpillar_climb = false
+fix_jump_distance_at_edge = true
+fix_edge_distance_check_when_climbing = true
+fix_painless_fall_on_guard = true
+fix_wall_bump_triggers_tile_below = true
+fix_stand_on_thin_air = true
+fix_press_through_closed_gates = true
+fix_grab_falling_speed = true
+fix_skeleton_chomper_blood = true
+fix_move_after_drink = true
+fix_loose_left_of_potion = true
+fix_guard_following_through_closed_gates = true
+fix_safe_landing_on_spikes = true

--- a/config.h
+++ b/config.h
@@ -32,7 +32,7 @@ The authors of this program may be contacted at http://forum.princed.org
 #define USE_FADE
 
 // Enable or disable the potions level. (copy protection)
-//#define USE_COPYPROT
+#define USE_COPYPROT
 
 // Enable or disable flashing.
 #define USE_FLASH
@@ -53,32 +53,33 @@ The authors of this program may be contacted at http://forum.princed.org
 // Enable quicksave/load feature.
 #define USE_QUICKSAVE
 
-// Adds a way to crouch immediately after climbing up: press down and forward simultaneously
-// In the original game, this could not be done (pressing down always causes the kid to climb down).
-//#define ALLOW_CROUCH_AFTER_CLIMBING
-
 // Enable one-minute penalty for quickloading
 #define USE_QUICKLOAD_PENALTY
 
-// Time passes while the level ending music plays; however, this can be skipped by disabling sound.
-// This disables time passing while the ending music is playing, so you can leave sounds on.
-//#define DISABLE_TIME_DURING_END_MUSIC
-
 // Enable recording/replay feature.
 #define USE_REPLAY
+
+// Adds a way to crouch immediately after climbing up: press down and forward simultaneously
+// In the original game, this could not be done (pressing down always causes the kid to climb down).
+#define ALLOW_CROUCH_AFTER_CLIMBING
+
+// Time passes while the level ending music plays; however, this can be skipped by disabling sound.
+// This disables time passing while the ending music is playing, so you can leave sounds on.
+#define FREEZE_TIME_DURING_END_MUSIC
+
 
 // Bugfixes:
 
 // The mentioned tricks can be found here: http://www.popot.org/documentation.php?doc=Tricks
 
 // If a room is linked to itself on the left, the closing sounds of the gates in that room can't be heard.
-//#define FIX_GATE_SOUNDS
+#define FIX_GATE_SOUNDS
 
 // An open gate or chomper may enable the Kid to go through walls. (Trick 7, 37, 62)
-//#define FIX_TWO_COLL_BUG
+#define FIX_TWO_COLL_BUG
 
 // If a room is linked to itself at the bottom, and the Kid's column has no floors, the game hangs.
-//#define FIX_INFINITE_DOWN_BUG
+#define FIX_INFINITE_DOWN_BUG
 
 // When a gate is under another gate, the top of the bottom gate is not visible.
 // But this fix causes a drawing bug when a gate opens.
@@ -90,38 +91,38 @@ The authors of this program may be contacted at http://forum.princed.org
 
 // When climbing up two floors, turning around and jumping upward, the kid falls down.
 // This fix makes the workaround of Trick 25 unnecessary.
-//#define FIX_JUMP_DISTANCE_AT_EDGE
+#define FIX_JUMP_DISTANCE_AT_EDGE
 
 // When climbing to a higher floor, the game unnecessarily checks how far away the edge below is;
 // This contributes to sometimes "teleporting" considerable distances when climbing from firm ground
-//#define FIX_EDGE_DISTANCE_CHECK_WHEN_CLIMBING
+#define FIX_EDGE_DISTANCE_CHECK_WHEN_CLIMBING
 
 // Falling from a great height directly on top of guards does not hurt.
-//#define FIX_PAINLESS_FALL_ON_GUARD
+#define FIX_PAINLESS_FALL_ON_GUARD
 
 // Bumping against a wall may cause a loose floor below to drop, even though it has not been touched (Trick 18, 34)
-//#define FIX_WALL_BUMP_TRIGGERS_TILE_BELOW
+#define FIX_WALL_BUMP_TRIGGERS_TILE_BELOW
 
 // When pressing a loose tile, you can temporarily stand on thin air by standing up from crouching.
-//#define FIX_STAND_ON_THIN_AIR
+#define FIX_STAND_ON_THIN_AIR
 
 // Buttons directly to the right of gates can be pressed even though the gate is closed (Trick 1)
-//#define FIX_PRESS_THROUGH_CLOSED_GATES
+#define FIX_PRESS_THROUGH_CLOSED_GATES
 
 // By jumping and bumping into a wall, you can sometimes grab a ledge two stories down (which should not be possible).
-//#define FIX_GRAB_FALLING_SPEED
+#define FIX_GRAB_FALLING_SPEED
 
 // When chomped, skeletons cause the chomper to become bloody even though skeletons do not have blood.
-//#define FIX_SKELETON_CHOMPER_BLOOD
+#define FIX_SKELETON_CHOMPER_BLOOD
 
 // Controls do not get released properly when drinking a potion, sometimes causing unintended movements.
-//#define FIX_MOVE_AFTER_DRINK
+#define FIX_MOVE_AFTER_DRINK
 
 // A drawing bug occurs when a loose tile is placed to the left of a potion (or sword).
-//#define FIX_LOOSE_LEFT_OF_POTION
+#define FIX_LOOSE_LEFT_OF_POTION
 
 // Guards may "follow" the kid to the room on the left, even though there is a closed gate in between.
-//#define FIX_GUARD_FOLLOWING_THROUGH_CLOSED_GATES
+#define FIX_GUARD_FOLLOWING_THROUGH_CLOSED_GATES
 
 
 // Debug features:

--- a/config.h
+++ b/config.h
@@ -64,6 +64,9 @@ The authors of this program may be contacted at http://forum.princed.org
 // This disables time passing while the ending music is playing, so you can leave sounds on.
 //#define DISABLE_TIME_DURING_END_MUSIC
 
+// Enable recording/replay feature.
+#define USE_REPLAY
+
 // Bugfixes:
 
 // The mentioned tricks can be found here: http://www.popot.org/documentation.php?doc=Tricks

--- a/data.h
+++ b/data.h
@@ -559,6 +559,7 @@ word last_loose_sound;
 byte recording INIT(= 0);
 byte replaying INIT(= 0);
 dword num_replay_ticks INIT(= 0);
+byte need_replay_cycle INIT(= 0);
 #endif // USE_REPLAY
 
 #undef INIT

--- a/data.h
+++ b/data.h
@@ -562,6 +562,8 @@ dword num_replay_ticks INIT(= 0);
 byte need_replay_cycle INIT(= 0);
 #endif // USE_REPLAY
 
+options_type options INIT(= {{0}});
+
 #undef INIT
 #undef extern
 

--- a/data.h
+++ b/data.h
@@ -555,6 +555,11 @@ word word_1E1AA;
 // data:5F84
 word last_loose_sound;
 
+#ifdef USE_REPLAY
+byte recording INIT(= 0);
+byte replaying INIT(= 0);
+dword num_replay_ticks INIT(= 0);
+#endif // USE_REPLAY
 
 #undef INIT
 #undef extern

--- a/doc/ChangeLog.txt
+++ b/doc/ChangeLog.txt
@@ -270,3 +270,11 @@ CHANGE: Sequence table deobfuscation.
 
 License:
 Added GPLv3 license (2015 June 27).
+
+2015 August 26
+==============
+(experimental version 1.16b3)
+
+DONE: Added ability to view or record replays. While in game, press Ctrl+Tab to stop/start recording. While at the title screen, press Tab to view/cycle saved replays. You can also open replays directly with SDLPoP (drag/drop on the executable or double click the replay file) and they will play immediately.
+DONE: Use SDLPoP.ini to configure gameplay options. Fixes for gameplay quirks are enabled by default but can be very easily disabled all at once by setting the topmost option 'disable_all_fixes' to 'true'.
+CHANGE: Minor build fixes.

--- a/doc/Readme.txt
+++ b/doc/Readme.txt
@@ -79,6 +79,10 @@ Alt-Enter: toggle fullscreen
 F6: quicksave
 F9: quickload
 
+Viewing or recording replays:
+Ctrl+Tab (in game): start or stop recording
+Tab (on title screen): view/cycle through the saved replays in the SDLPoP directory
+
 Cheats:
 Shift-L: go to next level
 c: show numbers of current and adjacent rooms
@@ -126,12 +130,38 @@ This is useful if you want to compare the behavior of this port and the original
 Note that this port does not recognize if the PRINCE.EXE of the mod was changed.
 
 Beware, some mods (especially the harder ones) might rely on bugs that are fixed in SDLPoP.
-You can turn these fixes off in config.h.
+Since version 1.16, you can turn gameplay fixes on or off in SDLPoP.ini.
+To simply get the exact behavior of the original game, set the first option (disable_all_fixes) to 'true'.
+However, you can also toggle individual fixes.
 
 Furthermore, SDLPoP opens up new possibilities for mod making.
 For example:
 Falcury released a mod, called "Secrets of the Citadel" that "has been designed to be played using a modified version of SDLPoP".
 Description and download: http://forum.princed.org/viewtopic.php?f=73&t=3664
+
+REPLAYS
+=======
+
+Q: How do replays work?
+A:
+Starting from version 1.16, you can capture or view replays in SDLPoP.
+To start recording, press Ctrl+Tab while in game. To stop recording, press Ctrl+Tab again.
+Your replays get saved in the SDLPoP folder as files with a .P1R extension (REPLAY_001.P1R, REPLAY_002.P1R, and so on).
+
+To view a replay, you can press Tab while on the title screen. 
+The game then looks for replays with the REPLAY_XXX.P1R pattern and plays those in order (you can cycle by pressing Tab again).
+You can also double-click on a replay file (and tell the OS that the file needs to be opened with the SDLPoP executable).
+SDLPoP will then immediately play that replay. Dragging and dropping onto the executable also works.
+
+Your settings specified in SDLPoP.ini (including whether you are playing with bugfixes on or off) are remembered in the replay.
+It shouldn't matter how SDLPoP.ini is set up when you are viewing the replay later.
+Note that any cheats you use do not get saved as part of the replay.
+
+If you want to start recording on a specific level, you can use the command "prince.exe record <lvl_number>",
+where <lvl_number> is the level on which you want to start.
+
+Also beware that the format of the replay files is not yet final and may change in the future!
+So it is possible that replays you record now will not work well in future versions.
 
 DEVELOPING
 ==========

--- a/options.c
+++ b/options.c
@@ -1,0 +1,165 @@
+/*
+SDLPoP, a port/conversion of the DOS game Prince of Persia.
+Copyright (C) 2013-2015  Dávid Nagy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+The authors of this program may be contacted at http://forum.princed.org
+*/
+
+#include "common.h"
+
+void use_default_options() {
+    options.disable_all_fixes = 0;
+    options.enable_copyprot = 0;
+    options.enable_mixer = 1;
+    options.enable_fade = 1;
+    options.enable_flash = 1;
+    options.enable_text = 1;
+    options.enable_quicksave = 1;
+    options.enable_quicksave_penalty = 1;
+    options.enable_replay = 1;
+    options.enable_crouch_after_climbing = 1;
+    options.enable_freeze_time_during_end_music = 1;
+    options.fix_gate_sounds = 1;
+    options.fix_two_coll_bug = 1;
+    options.fix_infinite_down_bug = 1;
+    options.fix_gate_drawing_bug = 0;
+    options.fix_bigpillar_climb = 0;
+    options.fix_jump_distance_at_edge = 1;
+    options.fix_edge_distance_check_when_climbing = 1;
+    options.fix_painless_fall_on_guard = 1;
+    options.fix_wall_bump_triggers_tile_below = 1;
+    options.fix_stand_on_thin_air = 1;
+    options.fix_press_through_closed_gates = 1;
+    options.fix_grab_falling_speed = 1;
+    options.fix_skeleton_chomper_blood = 1;
+    options.fix_move_after_drink = 1;
+    options.fix_loose_left_of_potion = 1;
+    options.fix_guard_following_through_closed_gates = 1;
+    options.fix_safe_landing_on_spikes = 1;
+}
+
+void disable_all_fixes() {
+    options.enable_crouch_after_climbing = 0;
+    options.enable_freeze_time_during_end_music = 0;
+    options.fix_gate_sounds = 0;
+    options.fix_two_coll_bug = 0;
+    options.fix_infinite_down_bug = 0;
+    options.fix_gate_drawing_bug = 0;
+    options.fix_bigpillar_climb = 0;
+    options.fix_jump_distance_at_edge = 0;
+    options.fix_edge_distance_check_when_climbing = 0;
+    options.fix_painless_fall_on_guard = 0;
+    options.fix_wall_bump_triggers_tile_below = 0;
+    options.fix_stand_on_thin_air = 0;
+    options.fix_press_through_closed_gates = 0;
+    options.fix_grab_falling_speed = 0;
+    options.fix_skeleton_chomper_blood = 0;
+    options.fix_move_after_drink = 0;
+    options.fix_loose_left_of_potion = 0;
+    options.fix_guard_following_through_closed_gates = 0;
+    options.fix_safe_landing_on_spikes = 0;
+}
+
+// .ini file parser adapted from https://gist.github.com/OrangeTide/947070
+/* Load an .ini format file
+ * filename - path to a file
+ * report - callback can return non-zero to stop, the callback error code is
+ *     returned from this function.
+ * return - return 0 on success
+ */
+int ini_load(const char *filename,
+             int (*report)(const char *section, const char *name, const char *value))
+{
+    char name[64];
+    char value[256];
+    char section[128] = "";
+    char *s;
+    FILE *f;
+    int cnt;
+
+    f = fopen(filename, "r");
+    if (!f) {
+        perror(filename);
+        return -1;
+    }
+
+    while (!feof(f)) {
+        if (fscanf(f, "[%127[^];\n]]\n", section) == 1) {
+        } else if ((cnt = fscanf(f, " %63[^=;\n] = %255[^;\n]", name, value))) {
+            if (cnt == 1)
+                *value = 0;
+            for (s = name + strlen(name) - 1; s > name && isspace(*s); s--)
+                *s = 0;
+            for (s = value + strlen(value) - 1; s > value && isspace(*s); s--)
+                *s = 0;
+            report(section, name, value);
+        }
+        fscanf(f, " ;%*[^\n]");
+        fscanf(f, " \n");
+    }
+
+    fclose(f);
+    return 0;
+}
+
+static int ini_callback(const char *section, const char *name, const char *value)
+{
+    //fprintf(stdout, "[%s] '%s'='%s'\n", section, name, value);
+    #define process(option)                                             \
+    if (strcasecmp(name, #option) == 0) {                               \
+        if (strcasecmp(value, "true") == 0) options.option = 1;         \
+        else if (strcasecmp(value, "false") == 0) options.option = 0;}
+    #define process_next(option) else process(option)
+
+    process(disable_all_fixes)
+    process_next(enable_copyprot)
+    process_next(enable_mixer)
+    process_next(enable_fade)
+    process_next(enable_flash)
+    process_next(enable_text)
+    process_next(enable_quicksave)
+    process_next(enable_quicksave_penalty)
+    process_next(enable_replay)
+    process_next(enable_crouch_after_climbing)
+    process_next(enable_freeze_time_during_end_music)
+    process_next(fix_gate_sounds)
+    process_next(fix_two_coll_bug)
+    process_next(fix_infinite_down_bug)
+    process_next(fix_gate_drawing_bug)
+    process_next(fix_bigpillar_climb)
+    process_next(fix_jump_distance_at_edge)
+    process_next(fix_edge_distance_check_when_climbing)
+    process_next(fix_painless_fall_on_guard)
+    process_next(fix_wall_bump_triggers_tile_below)
+    process_next(fix_stand_on_thin_air)
+    process_next(fix_press_through_closed_gates)
+    process_next(fix_grab_falling_speed)
+    process_next(fix_skeleton_chomper_blood)
+    process_next(fix_move_after_drink)
+    process_next(fix_loose_left_of_potion)
+    process_next(fix_guard_following_through_closed_gates)
+    process_next(fix_safe_landing_on_spikes)
+
+    #undef process_next
+    #undef process
+    return 0;
+}
+
+void load_options() {
+    use_default_options();
+    ini_load("SDLPoP.ini", ini_callback);
+    if (options.disable_all_fixes) disable_all_fixes();
+}

--- a/proto.h
+++ b/proto.h
@@ -179,7 +179,7 @@ void __pascal far autocontrol_shadow_level12();
 
 // SEG003.C
 void __pascal far init_game(int level);
-void __pascal far play_level(int level);
+void __pascal far play_level(int level_number);
 void __pascal far do_startpos();
 void __pascal far set_start_pos();
 void __pascal far find_start_level_door();
@@ -592,9 +592,15 @@ sound_buffer_type* load_sound(int index);
 void free_sound(sound_buffer_type far *buffer);
 
 // SEQTABLE.C
+void apply_seqtbl_patches();
 #ifdef CHECK_SEQTABLE_MATCHES_ORIGINAL
 void check_seqtable_matches_original();
 #endif
+
+// OPTIONS.C
+void use_default_options();
+void disable_all_fixes();
+void load_options();
 
 // REPLAY.C
 #ifdef USE_REPLAY

--- a/proto.h
+++ b/proto.h
@@ -607,7 +607,8 @@ void stop_recording();
 void start_replay();
 void do_replay_move();
 void save_recorded_replay();
-void load_recorded_replay();
+void replay_cycle();
+void load_replay();
 void key_press_while_recording(int* key_ptr);
 void key_press_while_replaying(int* key_ptr);
 #endif

--- a/proto.h
+++ b/proto.h
@@ -72,6 +72,7 @@ void __pascal far show_loading();
 void __pascal far show_quotes();
 #ifdef USE_QUICKSAVE
 void check_quick_op();
+void restore_room_after_quick_load();
 #endif // USE_QUICKSAVE
 
 // SEG001.C
@@ -593,4 +594,20 @@ void free_sound(sound_buffer_type far *buffer);
 // SEQTABLE.C
 #ifdef CHECK_SEQTABLE_MATCHES_ORIGINAL
 void check_seqtable_matches_original();
+#endif
+
+// REPLAY.C
+#ifdef USE_REPLAY
+void init_record_replay();
+void replay_restore_level();
+int restore_savestate_from_buffer();
+void start_recording();
+void add_replay_move();
+void stop_recording();
+void start_replay();
+void do_replay_move();
+void save_recorded_replay();
+void load_recorded_replay();
+void key_press_while_recording(int* key_ptr);
+void key_press_while_replaying(int* key_ptr);
 #endif

--- a/replay.c
+++ b/replay.c
@@ -1,0 +1,266 @@
+/*
+SDLPoP, a port/conversion of the DOS game Prince of Persia.
+Copyright (C) 2013-2015  Dávid Nagy
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+The authors of this program may be contacted at http://forum.princed.org
+*/
+
+#include "common.h"
+
+#ifdef USE_REPLAY
+
+#define MAX_REPLAY_DURATION 345600 // 8 hours: 720 * 60 * 8 ticks
+byte moves[MAX_REPLAY_DURATION] = {0}; // static memory for now because it is easier (should this be dynamic?)
+
+enum special_moves {
+    MOVE_RESTART_LEVEL = 1,
+};
+
+// 1-byte structure representing which controls were active at a particular game tick
+typedef union replay_move {
+    struct {
+        sbyte x : 2;
+        sbyte y : 2;
+        byte shift : 1;
+        byte special : 3;
+    };
+    byte bits;
+} replay_move;
+
+dword curr_tick = 0;
+dword saved_random_seed;
+byte special_move = 0;
+
+FILE* replay_fp;
+const char* const replay_file = "REPLAY.SAV";
+
+byte* savestate_buffer = NULL;
+size_t savestate_offset = 0;
+size_t savestate_size = 0;
+#define MAX_SAVESTATE_SIZE 4096
+
+// These are defined in seg000.c:
+typedef int process_func_type(void* data, size_t data_size);
+extern int quick_process(process_func_type process_func);
+extern const char const quick_version[];
+extern char quick_control[];
+
+void init_record_replay() {
+    if (check_param("record")) {
+        start_recording();
+    }
+    else if (check_param("replay")) {
+        start_replay();
+    }
+}
+
+void replay_restore_level() {
+    // Need to restore the savestate at the right time (just before the first room of the level is drawn).
+    // Otherwise, for "on-the-fly" recordings, the screen will visibly "jump" to the replay savestate.
+    // This only needs to happen at the very beginning of the replay (curr_tick == 0)
+    if (curr_tick == 0) restore_savestate_from_buffer();
+}
+
+int process_to_buffer(void* data, size_t data_size) {
+    if (savestate_offset + data_size > MAX_SAVESTATE_SIZE) {
+        printf("Saving savestate to memory failed: buffer is overflowing!\n");
+        return 0;
+    }
+    memcpy(savestate_buffer + savestate_offset, data, data_size);
+    savestate_offset += data_size;
+    return 1;
+}
+
+int process_load_from_buffer(void* data, size_t data_size) {
+    memcpy(data, savestate_buffer + savestate_offset, data_size);
+    savestate_offset += data_size;
+    return 1;
+}
+
+int savestate_to_buffer() {
+    int ok = 0;
+    if (savestate_buffer == NULL)
+        savestate_buffer = malloc(MAX_SAVESTATE_SIZE);
+    if (savestate_buffer != NULL) {
+        savestate_offset = 0;
+        savestate_size = 0;
+        ok = quick_process(process_to_buffer);
+        savestate_size = savestate_offset;
+    }
+    return ok;
+}
+
+
+int restore_savestate_from_buffer() {
+    int ok = 0;
+    savestate_offset = 0;
+    while (savestate_offset < savestate_size) {
+        ok = quick_process(process_load_from_buffer);
+    }
+    restore_room_after_quick_load();
+    return ok;
+}
+
+void start_recording() {
+    curr_tick = 0;
+    recording = 1; // further set-up is done in add_replay_move, on the first gameplay tick
+}
+
+void add_replay_move() {
+    if (curr_tick == 0) {
+        prandom(1); // make sure random_seed is initialized
+        saved_random_seed = random_seed;
+        seed_was_init = 1;
+        savestate_to_buffer(); // create a savestate in memory
+        display_text_bottom("RECORDING");
+        text_time_total = 24;
+        text_time_remaining = 24;
+    }
+
+    replay_move curr_move = {0};
+    curr_move.x = control_x;
+    curr_move.y = control_y;
+    if (control_shift) curr_move.shift = 1;
+
+    if (special_move)  {
+        curr_move.special = special_move;
+        special_move = 0;
+    }
+
+    moves[curr_tick] = curr_move.bits;
+
+    ++curr_tick;
+
+    if (curr_tick >= MAX_REPLAY_DURATION) { // max replay length exceeded
+        stop_recording();
+    }
+}
+
+void stop_recording() {
+    save_recorded_replay();
+    recording = 0;
+    display_text_bottom("REPLAY SAVED");
+    text_time_total = 24;
+    text_time_remaining = 24;
+}
+
+void start_replay() {
+    replaying = 1;
+    curr_tick = 0;
+    load_recorded_replay();
+}
+
+void do_replay_move() {
+    if (curr_tick == 0) {
+        random_seed = saved_random_seed;
+        seed_was_init = 1;
+    }
+    if (curr_tick == num_replay_ticks) { // recording is finished
+        replaying = 0;
+        start_level = 0;
+        start_game();
+    }
+
+    replay_move curr_move;
+    curr_move.bits = moves[curr_tick];
+
+    control_x = curr_move.x;
+    control_y = curr_move.y;
+    control_shift = (curr_move.shift) ? -1 : 0;
+
+    if (curr_move.special == MOVE_RESTART_LEVEL) { // restart level
+        stop_sounds();
+        is_restart_level = 1;
+    }
+
+//    if (curr_tick > 5 ) printf("rem_tick: %d\t curr_tick: %d\tlast 5 moves: %d, %d, %d, %d, %d\n", rem_tick, curr_tick,
+//                               moves[curr_tick-4], moves[curr_tick-3], moves[curr_tick-2], moves[curr_tick-1], moves[curr_tick]);
+    ++curr_tick;
+}
+
+void save_recorded_replay() {
+    replay_fp = fopen(replay_file, "wb");
+    if (replay_fp != NULL) {
+        // embed a savestate into the replay
+        fwrite(&savestate_size, sizeof(savestate_size), 1, replay_fp);
+        fwrite(savestate_buffer, savestate_size, 1, replay_fp);
+        // save the rest of the replay data
+        num_replay_ticks = curr_tick;
+        fwrite(&start_level, sizeof(start_level), 1, replay_fp);
+        fwrite(&saved_random_seed, sizeof(saved_random_seed), 1, replay_fp);
+        fwrite(&num_replay_ticks, sizeof(num_replay_ticks), 1, replay_fp);
+        fwrite(moves, num_replay_ticks, 1, replay_fp);
+        fclose(replay_fp);
+    }
+}
+
+void load_recorded_replay() {
+    replay_fp = fopen(replay_file, "rb");
+    if (savestate_buffer == NULL)
+        savestate_buffer = malloc(MAX_SAVESTATE_SIZE);
+    if (replay_fp != NULL && savestate_buffer != NULL) {
+        // load the savestate
+        fread(&savestate_size, sizeof(savestate_size), 1, replay_fp);
+        fread(savestate_buffer, savestate_size, 1, replay_fp);
+        // load the rest of the replay data
+        fread(&start_level, sizeof(start_level), 1, replay_fp);
+        fread(&saved_random_seed, sizeof(saved_random_seed), 1, replay_fp);
+        fread(&num_replay_ticks, sizeof(num_replay_ticks), 1, replay_fp);
+        fread(moves, num_replay_ticks, 1, replay_fp);
+        fclose(replay_fp);
+    }
+}
+
+void key_press_while_recording(int* key_ptr) {
+    int key = *key_ptr;
+    switch(key) {
+        case SDL_SCANCODE_A | WITH_CTRL:
+            special_move = MOVE_RESTART_LEVEL;
+            break;
+        case SDL_SCANCODE_R | WITH_CTRL:
+            save_recorded_replay();
+            recording = 0;
+        default:
+            break;
+    }
+}
+
+void key_press_while_replaying(int* key_ptr) {
+    int key = *key_ptr;
+    switch(key) {
+        default:
+            // cannot manually do most stuff during a replay!
+            *key_ptr = 0;
+            break;
+        // but these are allowable actions:
+        case SDL_SCANCODE_ESCAPE:               // pause
+        case SDL_SCANCODE_ESCAPE | WITH_SHIFT:
+        case SDL_SCANCODE_SPACE:                // time
+        case SDL_SCANCODE_S | WITH_CTRL:        // sound toggle
+        case SDL_SCANCODE_V | WITH_CTRL:        // version
+        case SDL_SCANCODE_C:                    // room numbers
+        case SDL_SCANCODE_C | WITH_SHIFT:
+        case SDL_SCANCODE_I | WITH_SHIFT:       // invert
+        case SDL_SCANCODE_B | WITH_SHIFT:       // blind
+        case SDL_SCANCODE_T:                    // debug time
+            break;
+        case SDL_SCANCODE_R | WITH_CTRL:        // restart game
+            replaying = 0;
+            break;
+    }
+}
+
+#endif // USE_REPLAY

--- a/seg000.c
+++ b/seg000.c
@@ -40,6 +40,9 @@ void far pop_main() {
 	check_seqtable_matches_original();
 	#endif
 
+	load_options();
+	apply_seqtbl_patches();
+
 	char sprintf_temp[100];
 	int i;
 
@@ -61,7 +64,15 @@ void far pop_main() {
 #endif
 	draw_mode = check_param("draw") && cheats_enabled;
 
-	if (cheats_enabled) {
+#ifdef USE_REPLAY
+	init_record_replay();
+#endif
+
+	if (cheats_enabled
+		#ifdef USE_REPLAY
+		|| recording
+        #endif
+			) {
 		for (i = 14; i >= 0; --i) {
 			snprintf(sprintf_temp, sizeof(sprintf_temp), "%d", i);
 			if (check_param(sprintf_temp)) {
@@ -95,10 +106,6 @@ void __pascal far init_game_main() {
 	load_sounds(0, 43);
 	load_opt_sounds(43, 56); //added
 	hof_read();
-
-#ifdef USE_REPLAY
-	init_record_replay();
-#endif
 	start_game();
 }
 
@@ -329,8 +336,10 @@ int quick_load() {
 
 		#ifdef USE_QUICKLOAD_PENALTY
 		// Subtract one minute from the remaining time (if it is above 5 minutes)
-		if (rem_min == 6) rem_tick = 719; // crop to "5 minutes" exactly, if hitting the threshold in <1 minute
-		if (rem_min > 5) --rem_min;
+		if (options.enable_quicksave_penalty) {
+			if (rem_min == 6) rem_tick = 719; // crop to "5 minutes" exactly, if hitting the threshold in <1 minute
+			if (rem_min > 5) --rem_min;
+		}
 		#endif
 	}
 	return ok;
@@ -340,6 +349,7 @@ int need_quick_save = 0;
 int need_quick_load = 0;
 
 void check_quick_op() {
+	if (!options.enable_quicksave) return;
 	if (need_quick_save) {
 		if (!is_feather_fall && quick_save()) {
 			display_text_bottom("QUICKSAVE");
@@ -489,8 +499,10 @@ int __pascal far process_key() {
 				} else {
 					if (current_level == 15 && cheats_enabled) {
 #ifdef USE_COPYPROT
-						next_level = copyprot_level;
-						copyprot_level = -1;
+                        if (options.enable_copyprot) {
+                        	next_level = copyprot_level;
+                        	copyprot_level = -1;
+                        }
 #endif
 					} else {
 						next_level = current_level + 1;
@@ -1531,7 +1543,7 @@ short __pascal far load_game() {
 	if (read(handle, &start_level, 2) != 2) goto loc_1E8E;
 	if (read(handle, &hitp_beg_lev, 2) != 2) goto loc_1E8E;
 #ifdef USE_COPYPROT
-	if (copyprot_level > 0) {
+	if (options.enable_copyprot && copyprot_level > 0) {
 		copyprot_level = start_level;
 	}
 #endif

--- a/seg000.c
+++ b/seg000.c
@@ -238,12 +238,26 @@ int quick_process(process_func_type process_func) {
 	// remaining time
 	process(rem_min);
 	process(rem_tick);
+	// saved controls
+	process(control_x);
+	process(control_y);
+	process(control_shift);
+	process(control_forward);
+	process(control_backward);
+	process(control_up);
+	process(control_down);
+	process(control_shift2);
+	process(ctrl1_forward);
+	process(ctrl1_backward);
+	process(ctrl1_up);
+	process(ctrl1_down);
+	process(ctrl1_shift2);
 #undef process
 	return ok;
 }
 
 const char* const quick_file = "QUICKSAVE.SAV";
-const char const quick_version[] = "V1.16   ";
+const char const quick_version[] = "V1.16b3 ";
 char quick_control[] = "........";
 
 int quick_save() {
@@ -276,9 +290,7 @@ void restore_room_after_quick_load() {
 
 	hitp_delta = guardhp_delta = 1; // force HP redraw
 	draw_hp();
-
-	// Kid should not move immediately after quickload
-	clear_saved_ctrl();
+	loadkid_and_opp();
 	// Get rid of "press button" message if kid was dead before quickload.
 	text_time_total = text_time_remaining = 0;
 	//next_sound = current_sound = -1;

--- a/seg000.c
+++ b/seg000.c
@@ -96,6 +96,9 @@ void __pascal far init_game_main() {
 	load_opt_sounds(43, 56); //added
 	hof_read();
 
+#ifdef USE_REPLAY
+	init_record_replay();
+#endif
 	start_game();
 }
 
@@ -255,6 +258,33 @@ int quick_save() {
 	return ok;
 }
 
+void restore_room_after_quick_load() {
+	int temp1 = curr_guard_color;
+	int temp2 = next_level;
+	load_lev_spr(current_level);
+	curr_guard_color = temp1;
+	next_level = temp2;
+
+	//need_full_redraw = 1;
+	different_room = 1;
+	next_room = drawn_room;
+	load_room_links();
+	//draw_level_first();
+	//gen_palace_wall_colors();
+	draw_game_frame(); // for falling
+	//redraw_screen(1); // for room_L
+
+	hitp_delta = guardhp_delta = 1; // force HP redraw
+	draw_hp();
+
+	// Kid should not move immediately after quickload
+	clear_saved_ctrl();
+	// Get rid of "press button" message if kid was dead before quickload.
+	text_time_total = text_time_remaining = 0;
+	//next_sound = current_sound = -1;
+	exit_room_timer = 0;
+}
+
 int quick_load() {
 
 	int ok = 0;
@@ -279,34 +309,11 @@ int quick_load() {
 		fclose(quick_fp);
 		quick_fp = NULL;
 
-		int temp1 = curr_guard_color;
-		int temp2 = next_level;
-		load_lev_spr(current_level);
-		curr_guard_color = temp1;
-		next_level = temp2;
-
-		//need_full_redraw = 1;
-		different_room = 1;
-		next_room = drawn_room;
-		load_room_links();
-		//draw_level_first();
-		//gen_palace_wall_colors();
-		draw_game_frame(); // for falling
-		//redraw_screen(1); // for room_L
-
-		hitp_delta = guardhp_delta = 1; // force HP redraw
-		draw_hp();
+		restore_room_after_quick_load();
 
 		do_wait(timer_0);
 		screen_updates_suspended = 0;
 		request_screen_update();
-
-		// Kid should not move immediately after quickload
-		clear_saved_ctrl();
-		// Get rid of "press button" message if kid was dead before quickload.
-		text_time_total = text_time_remaining = 0;
-		//next_sound = current_sound = -1;
-		exit_room_timer = 0;
 
 		#ifdef USE_QUICKLOAD_PENALTY
 		// Subtract one minute from the remaining time (if it is above 5 minutes)
@@ -367,6 +374,12 @@ int __pascal far process_key() {
 			#ifdef USE_QUICKSAVE
 			if (key == SDL_SCANCODE_F9) need_quick_load = 1;
 			#endif
+			#ifdef USE_REPLAY
+			if (key == SDL_SCANCODE_TAB) {
+				start_replay();
+			}
+			else
+			#endif
 			if (key == (SDL_SCANCODE_L | WITH_CTRL)) { // ctrl-L
 				if (!load_game()) return 0;
 			} else {
@@ -386,6 +399,10 @@ int __pascal far process_key() {
 	if (rem_min != 0 && Kid.alive > 6 && (control_shift || key == SDL_SCANCODE_RETURN)) {
 		key = SDL_SCANCODE_A | WITH_CTRL; // ctrl-a
 	}
+#ifdef USE_REPLAY
+	if (recording) key_press_while_recording(&key);
+	else if (replaying) key_press_while_replaying(&key);
+#endif
 	if (key == 0) return 0;
 	if (is_keyboard_mode) clear_kbd_buf();
 
@@ -483,6 +500,17 @@ int __pascal far process_key() {
 		case SDL_SCANCODE_F9 | WITH_SHIFT:
 			need_quick_load = 1;
 		break;
+#ifdef USE_REPLAY
+		case SDL_SCANCODE_TAB | WITH_CTRL:
+		case SDL_SCANCODE_TAB | WITH_CTRL | WITH_SHIFT:
+			if (recording) { // finished recording
+				stop_recording();
+			}
+			else { // should start recording
+				start_recording();
+			}
+			break;
+#endif // USE_RECORD_REPLAY
 #endif // USE_QUICKSAVE
 	}
 	if (cheats_enabled) {

--- a/seg002.c
+++ b/seg002.c
@@ -255,7 +255,7 @@ void __pascal far exit_room() {
 				// left
 				if (Guard.x >= 91) leave = 1;
 				#ifdef FIX_GUARD_FOLLOWING_THROUGH_CLOSED_GATES
-				else if (Guard.x > 0) {
+				else if (options.fix_guard_following_through_closed_gates && Guard.x > 0) {
 					get_tile(Kid.room, 9, Kid.curr_row);
 					if (curr_tile2 == tiles_4_gate && can_bump_into_gate())
 							leave = 1;

--- a/seg003.c
+++ b/seg003.c
@@ -67,25 +67,25 @@ const cutscene_ptr_type tbl_cutscenes[16] = {
 };
 
 // seg003:005C
-void __pascal far play_level(int level) {
+void __pascal far play_level(int level_number) {
 	cutscene_ptr_type cutscene_func;
 #ifdef USE_COPYPROT
-	if (level == copyprot_level) {
-		level = 15;
+	if (options.enable_copyprot && level_number == copyprot_level) {
+		level_number = 15;
 	}
 #endif
 	for (;;) {
-		if (demo_mode && level > 2) {
+		if (demo_mode && level_number > 2) {
 			start_level = 0;
 			word_1F05E = 1;
 			start_game();
 		}
-		if (level != current_level) {
-			if (level<0 || level>15) {
-				printf("Tried to load cutscene for level %d, not in 0..15", level);
+		if (level_number != current_level) {
+			if (level_number <0 || level_number >15) {
+				printf("Tried to load cutscene for level %d, not in 0..15", level_number);
 				quit(1);
 			}
-			cutscene_func = tbl_cutscenes[level];
+			cutscene_func = tbl_cutscenes[level_number];
 			if (cutscene_func != NULL
 
 				#ifdef USE_REPLAY
@@ -93,11 +93,11 @@ void __pascal far play_level(int level) {
 				#endif
 
 					) {
-				load_intro(level > 2, cutscene_func, 1);
+				load_intro(level_number > 2, cutscene_func, 1);
 			}
 		}
-		if (level != current_level) {
-			load_lev_spr(level);
+		if (level_number != current_level) {
+			load_lev_spr(level_number);
 		}
 		load_level();
 		pos_guards();
@@ -120,7 +120,7 @@ void __pascal far play_level(int level) {
 		Guard.charid = charid_2_guard;
 		Guard.direction = dir_56_none;
 		do_startpos();
-		have_sword = (level != 1);
+		have_sword = (level_number != 1);
 		find_start_level_door();
 		// busy waiting?
 		while (check_sound_playing() && !do_paused()) idle();
@@ -130,14 +130,14 @@ void __pascal far play_level(int level) {
 		#endif
 		draw_level_first();
 		show_copyprot(0);
-		level = play_level_2();
+		level_number = play_level_2();
 		// hacked...
 #ifdef USE_COPYPROT
-		if (level == copyprot_level && !demo_mode) {
-			level = 15;
+		if (options.enable_copyprot && level_number == copyprot_level && !demo_mode) {
+			level_number = 15;
 		} else {
-			if (level == 16) {
-				level = copyprot_level;
+			if (level_number == 16) {
+				level_number = copyprot_level;
 				copyprot_level = -1;
 			}
 		}
@@ -529,10 +529,12 @@ void __pascal far bump_into_opponent() {
 		if (ABS(distance) <= 15) {
 
 			#ifdef FIX_PAINLESS_FALL_ON_GUARD
-			if (Char.fall_y >= 33) return; // don't bump; dead
-			else if (Char.fall_y >= 22) { // medium land
-				take_hp(1);
-				play_sound(sound_16_medium_land);
+			if (options.fix_painless_fall_on_guard) {
+				if (Char.fall_y >= 33) return; // don't bump; dead
+				else if (Char.fall_y >= 22) { // medium land
+					take_hp(1);
+					play_sound(sound_16_medium_land);
+				}
 			}
 			#endif
 

--- a/seg003.c
+++ b/seg003.c
@@ -86,7 +86,13 @@ void __pascal far play_level(int level) {
 				quit(1);
 			}
 			cutscene_func = tbl_cutscenes[level];
-			if (cutscene_func != NULL) {
+			if (cutscene_func != NULL
+
+				#ifdef USE_REPLAY
+				&& !(recording || replaying)
+				#endif
+
+					) {
 				load_intro(level > 2, cutscene_func, 1);
 			}
 		}
@@ -119,6 +125,9 @@ void __pascal far play_level(int level) {
 		// busy waiting?
 		while (check_sound_playing() && !do_paused()) idle();
 		stop_sounds();
+		#ifdef USE_REPLAY
+		if (replaying) replay_restore_level();
+		#endif
 		draw_level_first();
 		show_copyprot(0);
 		level = play_level_2();

--- a/seg003.c
+++ b/seg003.c
@@ -315,6 +315,11 @@ int __pascal far play_level_2() {
 #ifdef USE_QUICKSAVE
 		check_quick_op();
 #endif // USE_QUICKSAVE
+
+#ifdef USE_REPLAY
+		if (need_replay_cycle) replay_cycle();
+#endif // USE_QUICKSAVE
+
 		if (Kid.sword == sword_2_drawn) {
 			// speed when fighting (smaller is faster)
 			start_timer(timer_1, 6);

--- a/seg004.c
+++ b/seg004.c
@@ -159,15 +159,24 @@ void __pascal far check_bumped() {
 		// frames 135..149: climb up
 		(Char.frame < frame_135_climbing_1 || Char.frame >= 149)
 	) {
+#ifdef FIX_TWO_COLL_BUG
 		if (bump_col_left_of_wall >= 0) {
 			check_bumped_look_right();
+			if (!options.fix_two_coll_bug) return; // check for the left-oriented collision only with the fix enabled
 		}
-#ifndef FIX_TWO_COLL_BUG
-		else
-#endif
 		if (bump_col_right_of_wall >= 0) {
 			check_bumped_look_left();
 		}
+#else
+		if (bump_col_left_of_wall >= 0) {
+			check_bumped_look_right();
+		}
+		else
+		if (bump_col_right_of_wall >= 0) {
+			check_bumped_look_left();
+		}
+#endif // FIX_TWO_COLL_BUG
+
 	}
 }
 
@@ -278,7 +287,7 @@ void __pascal far bumped_fall() {
 	if (action == actions_4_in_freefall) {
 		Char.fall_x = 0;
 	} else {
-		seqtbl_offset_char(seq_45_fall_after_bumped); // fall after bumped
+		seqtbl_offset_char(seq_45_bumpfall); // fall after bumped
 		play_seq();
 	}
 	bumped_sound();
@@ -312,7 +321,7 @@ void __pascal far bumped_floor(sbyte push_direction) {
 						(frame >= 40 && frame < 43) ||
 						(frame >= frame_102_start_fall_1 && frame < 107)
 					) {
-						seq_index = seq_46_bump_with_fall; // bump into wall after run-jump (crouch)
+						seq_index = seq_46_hardbump; // bump into wall after run-jump (crouch)
 					} else {
 						seq_index = seq_47_bump; // bump into wall
 					}
@@ -436,7 +445,7 @@ void __pascal far check_chomped_kid() {
 // seg004:07BF
 void __pascal far chomped() {
 	#ifdef FIX_SKELETON_CHOMPER_BLOOD
-	if (Char.charid != charid_4_skeleton)
+	if (!(options.fix_skeleton_chomper_blood && Char.charid == charid_4_skeleton))
 	#endif
 		curr_room_modif[curr_tilepos] |= 0x80; // put blood
 	if (Char.frame != frame_178_chomped && Char.room == curr_room) {

--- a/seg006.c
+++ b/seg006.c
@@ -1202,6 +1202,10 @@ void __pascal far control_kid() {
 	} else {
 		rest_ctrl_1();
 		do_paused();
+		#ifdef USE_REPLAY
+		if (recording) add_replay_move();
+		if (replaying) do_replay_move();
+		#endif
 		read_user_control();
 		user_control();
 		save_ctrl_1();

--- a/seg006.c
+++ b/seg006.c
@@ -24,7 +24,6 @@ The authors of this program may be contacted at http://forum.princed.org
 #define SEQTBL_0 (seqtbl - SEQTBL_BASE)
 extern const byte seqtbl[]; // the sequence table is defined in seqtbl.c
 
-
 // seg006:0006
 int __pascal far get_tile(int room,int col,int row) {
 	curr_room = room;
@@ -808,7 +807,8 @@ void __pascal far check_action() {
 		if (frame == frame_109_crouch
 
 			#ifdef FIX_STAND_ON_THIN_AIR
-			|| (frame >= frame_110_stand_up_from_crouch_1 && frame <= frame_119_stand_up_from_crouch_10)
+			|| (options.fix_stand_on_thin_air &&
+				frame >= frame_110_stand_up_from_crouch_1 && frame <= frame_119_stand_up_from_crouch_10)
 			#endif
 
 				) {
@@ -1036,7 +1036,7 @@ void __pascal far check_grab() {
 	word old_x;
 
 	#ifdef FIX_GRAB_FALLING_SPEED
-	#define MAX_GRAB_FALLING_SPEED 30
+	#define MAX_GRAB_FALLING_SPEED (options.fix_grab_falling_speed ? 30 : 32)
 	#else
 	#define MAX_GRAB_FALLING_SPEED 32
 	#endif
@@ -1470,7 +1470,7 @@ void __pascal far check_press() {
 			// the pressed tile is the one that the char is standing on
 			if (! (cur_frame.flags & FRAME_NEEDS_FLOOR)) return;
 			#ifdef FIX_PRESS_THROUGH_CLOSED_GATES
-			determine_col();
+			if (options.fix_press_through_closed_gates) determine_col();
 			#endif
 			get_tile_at_char();
 		}
@@ -1510,7 +1510,7 @@ void __pascal far check_spike_below() {
 				! tile_is_floor(curr_tile2) &&
 				curr_room != 0 &&
 #ifdef FIX_INFINITE_DOWN_BUG
-				row <= 2
+				(options.fix_infinite_down_bug ? (row <= 2) : (room == curr_room))
 #else
 				room == curr_room
 #endif

--- a/seg007.c
+++ b/seg007.c
@@ -1227,15 +1227,21 @@ void __pascal far play_door_sound_if_visible(int sound_id) {
 	tilepos = trob.tilepos;
 	gate_room = trob.room;
 	has_sound = 0;
-	// Special event: sound of closing gates
-	if ((current_level == 3 && gate_room == 2) || (
+
 #ifdef FIX_GATE_SOUNDS
-		(gate_room == room_L && tilepos % 10 == 9) ||
+	sbyte has_sound_condition;
+	if (options.fix_gate_sounds)
+		has_sound_condition = 	(gate_room == room_L && tilepos % 10 == 9) ||
+							  	(gate_room == drawn_room && tilepos % 10 != 9);
+	else has_sound_condition = 	gate_room == room_L ? tilepos % 10 == 9 :
+							   	(gate_room == drawn_room && tilepos % 10 != 9);
+	#define GATE_SOUND_CONDITION has_sound_condition
 #else
-		gate_room == room_L ? tilepos % 10 == 9 :
+	#define GATE_SOUND_CONDITION gate_room == room_L ? tilepos % 10 == 9 : 			\
+							   	(gate_room == drawn_room && tilepos % 10 != 9)
 #endif
-		(gate_room == drawn_room && tilepos % 10 != 9))
-	) {
+	// Special event: sound of closing gates
+	if ((current_level == 3 && gate_room == 2) || GATE_SOUND_CONDITION) {
 		has_sound = 1;
 	}
 	if (has_sound) {

--- a/seg008.c
+++ b/seg008.c
@@ -255,7 +255,7 @@ int __pascal far get_tile_to_draw(int room, int column, int row, byte *ptr_tilet
 		}
 	}
 #ifdef FIX_LOOSE_LEFT_OF_POTION
-	else if (tiletype == tiles_11_loose) {
+	else if (options.fix_loose_left_of_potion && tiletype == tiles_11_loose) {
 		if ((*ptr_modifier & 0x7F) == 0) {
 			*ptr_tiletype = tiles_1_floor;
 		}
@@ -1519,8 +1519,8 @@ void __pascal far show_time() {
 	char sprintf_temp[40];
 	word rem_sec;
 	if (Kid.alive < 0 &&
-		#ifdef DISABLE_TIME_DURING_END_MUSIC
-		next_level == current_level &&
+		#ifdef FREEZE_TIME_DURING_END_MUSIC
+		(!(options.enable_freeze_time_during_end_music && next_level != current_level)) &&
 		#endif
 		rem_min != 0 &&
 		(current_level < 13 || (current_level == 13 && leveldoor_open == 0)) &&

--- a/seg009.c
+++ b/seg009.c
@@ -2437,6 +2437,7 @@ void __pascal far set_bg_attr(int vga_pal_index,int hc_pal_index) {
 	// stub
 #ifdef USE_FLASH
 	//palette[vga_pal_index] = vga_palette[hc_pal_index];
+	if (!options.enable_flash) return;
 	if (vga_pal_index == 0) {
 		/*
 		if (SDL_SetAlpha(offscreen_surface, SDL_SRCALPHA, 0) != 0) {

--- a/seg009.c
+++ b/seg009.c
@@ -86,6 +86,11 @@ int __pascal far key_test_quit() {
 	word key;
 	key = read_key();
 	if (key == (SDL_SCANCODE_Q | WITH_CTRL)) { // ctrl-q
+
+		#ifdef USE_REPLAY
+		if (recording) save_recorded_replay();
+		#endif
+
 		quit(0);
 	}
 	return key;

--- a/types.h
+++ b/types.h
@@ -877,8 +877,8 @@ enum seqids {
 	seq_42_safe_step_14 = 42,
 	seq_43_start_run_after_turn = 43,
 	seq_44_step_on_edge = 44,
-	seq_45_fall_after_bumped = 45,
-	seq_46_bump_with_fall = 46,
+	seq_45_bumpfall = 45,
+	seq_46_hardbump = 46,
 	seq_47_bump = 47,
 	seq_49_stand_up_from_crouch = 49,
 	seq_50_crouch = 50,
@@ -978,5 +978,51 @@ enum key_modifiers {
 	WITH_CTRL  = 0x4000,
 	WITH_ALT   = 0x2000,
 };
+
+
+typedef union options_type {
+	// Need a predictable total size for forward compatibility (options data stored in replays for correct behavior!)
+	byte data[64];
+	struct {
+		byte disable_all_fixes; // kill-switch for all changes that modify gameplay behavior
+
+		// Main game options
+		byte enable_copyprot;
+
+		// Technical options
+		byte enable_mixer;
+		byte enable_fade;
+		byte enable_flash;
+		byte enable_text;
+
+		// Additional features on/off
+		byte enable_quicksave;
+		byte enable_quicksave_penalty;
+		byte enable_replay;
+
+		// Gameplay changes
+		byte enable_crouch_after_climbing;
+		byte enable_freeze_time_during_end_music;
+
+		// Bug fixes
+		byte fix_gate_sounds;
+		byte fix_two_coll_bug;
+		byte fix_infinite_down_bug;
+		byte fix_gate_drawing_bug;
+		byte fix_bigpillar_climb;
+		byte fix_jump_distance_at_edge;
+		byte fix_edge_distance_check_when_climbing;
+		byte fix_painless_fall_on_guard;
+		byte fix_wall_bump_triggers_tile_below;
+		byte fix_stand_on_thin_air;
+		byte fix_press_through_closed_gates;
+		byte fix_grab_falling_speed;
+		byte fix_skeleton_chomper_blood;
+		byte fix_move_after_drink;
+		byte fix_loose_left_of_potion;
+		byte fix_guard_following_through_closed_gates;
+		byte fix_safe_landing_on_spikes;
+	};
+} options_type;
 
 #endif


### PR DESCRIPTION
Note: builds on #22 and #23.

Options can now be configured in SDLPoP.ini without recompiling.
All fixes can be toggled individually; however, the kill-switch 'disable_all_fixes' restores all original gameplay quirks.
The preprocessor macros for the optional features/fixes are still in place but mostly assumed to be enabled.
To make the seqtbl fixes optional, I had to write a separate patching function (`apply_seqtbl_patches()`).
Some options do not actually work yet (enable_mixer, enable_fade, enable_text, fix_gate_drawing_bug, fix_bigpillar_climb).

Other changes:
- Replays now do a version check and warn if the format is unexpected
- Replays use the options that were in effect during the recording (to give predictable results)
- The command-line option `record <lvl_number>` now works properly when cheat mode is off
- The copy protection code is now re-enabled (but only active when the option is turned on in SDLPoP.ini)
- Minor build fixes and other fixes
- Updated ChangeLog and Readme