### PR TITLE
Add collision vars, Char, Opp to quicksave list to fix unexpected behaviour

### DIFF
--- a/seg000.c
+++ b/seg000.c
@@ -211,6 +211,8 @@ int quick_process(process_func_type process_func) {
 	process(word_1EFCE);
 	// guard
 	process(Guard);
+	process(Char);
+	process(Opp);
 	process(guardhp_curr);
 	process(guardhp_max);
 	process(demo_index);

--- a/seg000.c
+++ b/seg000.c
@@ -223,13 +223,13 @@ int quick_process(process_func_type process_func) {
 	process(word_1E1AA);
 	process(word_1EA12);
 	// collision
-	/*process(curr_row_coll_room);
+	process(curr_row_coll_room);
 	process(curr_row_coll_flags);
 	process(below_row_coll_room);
 	process(below_row_coll_flags);
 	process(above_row_coll_room);
 	process(above_row_coll_flags);
-	process(prev_collision_row);*/
+	process(prev_collision_row);
 	// flash
 	process(flash_color);
 	process(flash_time);
@@ -264,7 +264,7 @@ int quick_process(process_func_type process_func) {
 }
 
 const char* const quick_file = "QUICKSAVE.SAV";
-const char const quick_version[] = "V1.16b3 ";
+const char const quick_version[] = "V1.16b4 ";
 char quick_control[] = "........";
 
 int quick_save() {


### PR DESCRIPTION
This adds collision data and the Char and Opp structs to the list of quicksaved variables, in order to resolve some unexpected behaviour when quickloading (see commit messages).