### PR TITLE
Add a prompt for gameplay fixes and enhancements

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -2,15 +2,27 @@
 ; SDLPoP configuration
 ; ====================
 
-disable_all_fixes = false
+[General]
 enable_copyprot = false
 enable_mixer = true
 enable_fade = true
 enable_flash = true
 enable_text = true
+
+[AdditionalFeatures]
 enable_quicksave = true
 enable_quicksave_penalty = true
 enable_replay = true
+
+[Gameplay]
+use_fixes_and_enhancements = prompt
+
+;    'prompt' --> the game will ask each time the game is launched (Default)
+;    'true'   --> fixes and enhancements are used
+;    'false'  --> fixes and enhancements are not used
+;
+; Below, you can pick which fixes/enhancements will be active:
+
 enable_crouch_after_climbing = true
 enable_freeze_time_during_end_music = true
 fix_gate_sounds = true

--- a/doc/Readme.txt
+++ b/doc/Readme.txt
@@ -130,9 +130,11 @@ This is useful if you want to compare the behavior of this port and the original
 Note that this port does not recognize if the PRINCE.EXE of the mod was changed.
 
 Beware, some mods (especially the harder ones) might rely on bugs that are fixed in SDLPoP.
-Since version 1.16, you can turn gameplay fixes on or off in SDLPoP.ini.
-To simply get the exact behavior of the original game, set the first option (disable_all_fixes) to 'true'.
-However, you can also toggle individual fixes.
+Since version 1.16, SDLPoP will ask you whether gameplay quirks should be fixed or not.
+You can set your choice permanently in the file 'SDLPoP.ini':
+- Set the option 'use_fixes_and_enhancements' to 'false' to get the exact behavior of the original game.
+- Alternatively, set the option 'use_fixes_and_enhancements' to 'true'. You can then also enable or disable 
+  individual fixes and enhancements, depending on your preference.
 
 Furthermore, SDLPoP opens up new possibilities for mod making.
 For example:

--- a/options.c
+++ b/options.c
@@ -173,7 +173,7 @@ void load_options() {
 void show_disable_fixes_prompt() {
     if (options.use_fixes_and_enhancements != 2) return;
     draw_rect(&screen_rect, 0);
-    show_text(&screen_rect, 0, 0, "Enable bug fixes and\ngameplay enhancements?\n\nNOTE: This option disables some game quirks.\n\n\nY:  enhanced behavior \nN:  original behavior    \n\nY / N ?\n\n\n To set your preferences, you can edit the file 'SDLPoP.ini'");
+    show_text(&screen_rect, 0, 0, "\nEnable bug fixes and\ngameplay enhancements?\n\nNOTE:\nThis option disables some game quirks.\nCertain tricks will no longer work by default.\n\n\nY:  enhanced behavior \nN:  original behavior    \n\nY / N ?\n\n\n\nYou can fine-tune your preferences\nand/or bypass this screen by editing the file\n'SDLPoP.ini'");
     SDL_Event event;
     while (options.use_fixes_and_enhancements == 2 ) {
         SDL_WaitEvent(&event);

--- a/proto.h
+++ b/proto.h
@@ -599,8 +599,9 @@ void check_seqtable_matches_original();
 
 // OPTIONS.C
 void use_default_options();
-void disable_all_fixes();
+void disable_fixes_and_enhancements();
 void load_options();
+void show_disable_fixes_prompt();
 
 // REPLAY.C
 #ifdef USE_REPLAY

--- a/replay.c
+++ b/replay.c
@@ -1,6 +1,6 @@
 /*
 SDLPoP, a port/conversion of the DOS game Prince of Persia.
-Copyright (C) 2013-2015  Dávid Nagy
+Copyright (C) 2013-2015  Dï¿½vid Nagy
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -187,7 +187,7 @@ void stop_recording() {
 void apply_replay_options() {
     stored_options = options;
     options = replay_options;
-    if (options.disable_all_fixes) disable_all_fixes();
+    if (!options.use_fixes_and_enhancements) disable_fixes_and_enhancements();
     // but it does not make sense to apply these as well:
     options.enable_mixer = stored_options.enable_mixer;
     options.enable_fade = stored_options.enable_fade;
@@ -200,7 +200,7 @@ void apply_replay_options() {
 
 void apply_stored_options() {
     options = stored_options;
-    if (options.disable_all_fixes) disable_all_fixes();
+    if (!options.use_fixes_and_enhancements) disable_fixes_and_enhancements();
 }
 
 void start_replay() {

--- a/seg000.c
+++ b/seg000.c
@@ -63,6 +63,7 @@ void far pop_main() {
 	cheats_enabled = 1; // debug
 #endif
 	draw_mode = check_param("draw") && cheats_enabled;
+	demo_mode = check_param("demo");
 
 #ifdef USE_REPLAY
 	init_record_replay();

--- a/seg000.c
+++ b/seg000.c
@@ -107,6 +107,7 @@ void __pascal far init_game_main() {
 	load_sounds(0, 43);
 	load_opt_sounds(43, 56); //added
 	hof_read();
+	show_disable_fixes_prompt(); // added
 	start_game();
 }
 

--- a/seg009.c
+++ b/seg009.c
@@ -809,7 +809,7 @@ void load_font() {
 int __pascal far get_char_width(byte character) {
 	font_type* font = textstate.ptr_font;
 	int width = 0;
-	if (character <= font->last_char && character >= font->first_char) {
+	if (character != '\n' && character <= font->last_char && character >= font->first_char) {
 		width += font->chtab->images[character - font->first_char]->w; //char_ptrs[character - font->first_char]->width;
 		if (width) width += font->space_between_chars;
 	}
@@ -829,7 +829,7 @@ int __pascal far find_linebreak(const char far *text,int length,int break_width,
 		if (curr_line_width <= break_width) {
 			++curr_char_pos;
 			char curr_char = *(text_pos++);
-			if (curr_char == '\r') {
+			if (curr_char == '\n') {
 				return curr_char_pos;
 			}
 			if (curr_char == '-' ||
@@ -867,7 +867,7 @@ int __pascal far draw_text_character(byte character) {
 	//printf("going to do draw_text_character...\n");
 	font_type* font = textstate.ptr_font;
 	int width = 0;
-	if (character <= font->last_char && character >= font->first_char) {
+	if (character != '\n' && character <= font->last_char && character >= font->first_char) {
 		image_type* image = font->chtab->images[character - font->first_char]; //char_ptrs[character - font->first_char];
 		method_3_blit_mono(image, textstate.current_x, textstate.current_y - font->height_above_baseline, textstate.textblit, textstate.textcolor);
 		width = font->space_between_chars + image->w;
@@ -957,7 +957,7 @@ const rect_type far *__pascal draw_text(const rect_type far *rect_ptr,int x_alig
 		if (x_align < 0 &&
 			*line_pos == ' ' &&
 			i != 0 &&
-			*(line_pos-1) != '\r'
+			*(line_pos-1) != '\n'
 		) {
 			// Skip over space if it's not at the beginning of a line.
 			++line_pos;

--- a/types.h
+++ b/types.h
@@ -984,7 +984,7 @@ typedef union options_type {
 	// Need a predictable total size for forward compatibility (options data stored in replays for correct behavior!)
 	byte data[64];
 	struct {
-		byte disable_all_fixes; // kill-switch for all changes that modify gameplay behavior
+		byte use_fixes_and_enhancements; // kill-switch for all changes that modify gameplay behavior
 
 		// Main game options
 		byte enable_copyprot;


### PR DESCRIPTION
Note: this depends on the `show_text()` fix in #26 

This adds a prompt for choosing whether or not fixes and enhancements should be used. As suggested by Norbert.

The relevant INI option is now called 'use_fixes_and_enhancements' instead of 'disable_all_fixes' (the meaning has become opposite as well)
By default, the game asks whether to enable or disable the fixes upon launch.
Changing the setting in the INI file from 'prompt' to either 'true' or 'false' prevents the prompt from being shown.
Updated the Readme accordingly.

Also partitioned the INI file into `[General]`, `[AdditionalFeatures]` and `[Gameplay]` sections.