### PR TITLE
Add dialog and fix open potion placement in copyprot level

### DIFF
--- a/data.h
+++ b/data.h
@@ -78,7 +78,19 @@ extern const char copyprot_letter[] INIT(= {'A','A','B','B','C','C','D','D','E',
 // data:4620
 extern word cplevel_entr[14];
 #endif
-
+// data:46C6
+extern dialog_type* copyprot_dialog;
+// data:2944
+extern dialog_settings_type dialog_settings
+    INIT(= {
+         add_dialog_rect,
+         dialog_method_2_frame,
+         4, 4, 4, 4, 3, 4, 1
+    });
+// data:2B76
+extern rect_type dialog_rect_1 INIT(= {60, 56, 124, 264});
+// data:2B7E
+extern rect_type dialog_rect_2 INIT(= {61, 56, 120, 264});
 
 // data:409E
 extern word drawn_room;
@@ -97,6 +109,8 @@ extern tile_and_mod row_below_left_[10];
 // data:2274
 extern const word tbl_line[] INIT(= {0, 10, 20});
 
+// data:5966
+extern word loaded_room;
 // data:658A
 extern byte* curr_room_tiles;
 // data:5F88
@@ -152,7 +166,7 @@ extern back_table_type backtable[200];
 // data:3D38
 extern midtable_type midtable[50];
 // data:5F1E
-extern peel_type peels_table[50];
+extern peel_type* peels_table[50];
 // data:4D9A
 extern rect_type drects[30];
 
@@ -495,6 +509,8 @@ extern word kid_sword_strike;
 
 // data:6591
 extern byte edge_type;
+
+
 
 // data:596C
 extern SDL_Surface* onscreen_surface_;

--- a/proto.h
+++ b/proto.h
@@ -537,8 +537,8 @@ void __pascal far draw_rect(const rect_type far *rect,int color);
 surface_type far *__pascal rect_sthg(surface_type *surface,const rect_type far *rect);
 rect_type far *__pascal shrink2_rect(rect_type far *target_rect,const rect_type far *source_rect,int delta_x,int delta_y);
 void __pascal far set_curr_pos(int xpos,int ypos);
-void __pascal far restore_peel(peel_type peel_ptr);
-peel_type __pascal far read_peel_from_screen(const rect_type far *rect);
+void __pascal far restore_peel(peel_type *peel_ptr);
+peel_type* __pascal far read_peel_from_screen(const rect_type far *rect);
 void __pascal far show_text(const rect_type far *rect_ptr,int x_align,int y_align,const char far *text);
 int __pascal far intersect_rect(rect_type far *output,const rect_type far *input1,const rect_type far *input2);
 rect_type far * __pascal far union_rect(rect_type far *output,const rect_type far *input1,const rect_type far *input2);
@@ -574,6 +574,14 @@ rect_type far *__pascal offset2_rect(rect_type far *dest, const rect_type far *s
 void __pascal far show_text_with_color(const rect_type far *rect_ptr,int x_align,int y_align, const char far *text,int color);
 void __pascal do_simple_wait(int timer_index);
 void idle();
+void __pascal far init_copyprot_dialog();
+dialog_type * __pascal far make_dialog_info(dialog_settings_type *settings, rect_type *dialog_rect,
+                                            rect_type *text_rect, peel_type *dialog_peel);
+void __pascal far calc_dialog_peel_rect(dialog_type*dialog);
+void __pascal far read_dialog_peel(dialog_type *dialog);
+void __pascal far draw_dialog_frame(dialog_type *dialog);
+void __pascal far add_dialog_rect(dialog_type *dialog);
+void __pascal far dialog_method_2_frame(dialog_type *dialog);
 #ifdef USE_FADE
 void __pascal far fade_in_2(surface_type near *source_surface,int which_rows);
 palette_fade_type far *__pascal make_pal_buffer_fadein(surface_type *source_surface,int which_rows,int wait_time);

--- a/seg000.c
+++ b/seg000.c
@@ -65,6 +65,7 @@ void far pop_main() {
 	draw_mode = check_param("draw") != NULL && cheats_enabled;
 	demo_mode = check_param("demo") != NULL;
 
+	init_copyprot_dialog();
 #ifdef USE_REPLAY
 	init_record_replay();
 #endif

--- a/seg001.c
+++ b/seg001.c
@@ -562,7 +562,7 @@ void __pascal far remove_flash() {
 
 // seg001:09D7
 void __pascal far end_sequence() {
-	peel_type peel;
+	peel_type* peel;
 	short bgcolor;
 	short color;
 	rect_type rect;

--- a/seg008.c
+++ b/seg008.c
@@ -1146,10 +1146,10 @@ void __pascal far load_alter_mod(int tilepos) {
 #ifdef USE_COPYPROT
 			if (current_level == 15) {
 				// Copy protection
-				if (copyprot_room[copyprot_plac] == copyprot_plac &&
+				if (copyprot_room[copyprot_plac] == loaded_room &&
 					copyprot_tile[copyprot_plac] == tilepos
 				) {
-					*curr_tile_modif = 0xC0; // place open potion
+					*curr_tile_modif = 6 << 3; // place open potion
 				}
 			}
 #endif
@@ -1261,11 +1261,11 @@ void __pascal far draw_tables() {
 
 // seg008:1C4E
 void __pascal far restore_peels() {
-	peel_type peel;
+	peel_type* peel;
 	while (peels_count--) {
 		peel = peels_table[peels_count];
 		if (need_drects) {
-			add_drect(&peel.rect); // ?
+			add_drect(&peel->rect); // ?
 		}
 		restore_peel(peel);
 	}
@@ -1321,6 +1321,7 @@ void __pascal far draw_leveldoor() {
 
 // seg008:1E0C
 void __pascal far get_room_address(int room) {
+	loaded_room = (word) room;
 	if (room) {
 		curr_room_tiles = &level.fg[(room-1)*30];
 		curr_room_modif = &level.bg[(room-1)*30];
@@ -1691,7 +1692,7 @@ short __pascal far calc_screen_x_coord(short logical_x) {
 void __pascal far free_peels() {
 	while (peels_count > 0) {
 		--peels_count;
-		free_peel(&peels_table[peels_count]);
+		free_peel(peels_table[peels_count]);
 	}
 }
 

--- a/seg009.c
+++ b/seg009.c
@@ -575,6 +575,7 @@ void __pascal far free_surface(surface_type *surface) {
 // seg009:17EA
 void __pascal far free_peel(peel_type *peel_ptr) {
 	SDL_FreeSurface(peel_ptr->peel);
+	free(peel_ptr);
 }
 
 const rgb_type vga_palette[] = {
@@ -1021,39 +1022,139 @@ void __pascal far set_curr_pos(int xpos,int ypos) {
 	textstate.current_y = ypos;
 }
 
+// seg009:145A
+void __pascal far init_copyprot_dialog() {
+	copyprot_dialog = make_dialog_info(&dialog_settings, &dialog_rect_1, &dialog_rect_1, NULL);
+	copyprot_dialog->peel = read_peel_from_screen(&copyprot_dialog->peel_rect);
+}
+
 // seg009:0838
 int __pascal far showmessage(char far *text,int arg_4,void far *arg_0) {
-#if 0
 	word key;
 	rect_type rect;
-	font_type* saved_font_ptr;
-	surface_type* old_target;
-	old_target = current_target_surface;
-	current_target_surface = onscreen_surface_;
-	method_1_blit_rect(word_1F942->0x14, onscreen_surface_, &word_1F942->0x0A, &word_1F942->0x0A, 0);
-	sub_D16E(word_1F942);
-	saved_font_ptr = current_target_surface->ptr_font;
-	current_target_surface->ptr_font = ptr_font;
-	shrink2_rect(&rect, word_1F942->0x02, 2, 1);
-	show_text_with_color(&rect, 0, 0, text, 15);
-	current_target_surface->ptr_font = saved_font_ptr;
+	//font_type* saved_font_ptr;
+	//surface_type* old_target;
+	//old_target = current_target_surface;
+	//current_target_surface = onscreen_surface_;
+	// In the disassembly there is some messing with the current_target_surface and font (?)
+	// However, this does not seem to be strictly necessary
+	method_1_blit_rect(offscreen_surface, onscreen_surface_, &copyprot_dialog->peel_rect, &copyprot_dialog->peel_rect, 0);
+	draw_dialog_frame(copyprot_dialog);
+	//saved_font_ptr = textstate.ptr_font;
+	//saved_font_ptr = current_target_surface->ptr_font;
+	//current_target_surface->ptr_font = ptr_font;
+	shrink2_rect(&rect, &copyprot_dialog->text_rect, 2, 1);
+	show_text_with_color(&rect, 0, 0, text, color_15_white);
+	screen_updates_suspended = 0;
+	request_screen_update();
+	//textstate.ptr_font = saved_font_ptr;
+	//current_target_surface->ptr_font = saved_font_ptr;
 	clear_kbd_buf();
 	do {
-		key = key_test_quit();
+		idle();
+		key = key_test_quit(); // Press any key to continue...
 	} while(key == 0);
-	sub_DF99(word_1F942->0x14);
-	current_target_surface = old_target;
+	//restore_dialog_peel_2(copyprot_dialog->peel);
+	//current_target_surface = old_target;
+	redraw_screen(0); // lazy: instead of neatly restoring only the relevant part, just redraw the whole screen
 	return key;
-#else // 0
-	return 0;
-#endif // 0
+}
+
+// seg009:08FB
+dialog_type * __pascal far make_dialog_info(dialog_settings_type *settings, rect_type *dialog_rect,
+											rect_type *text_rect, peel_type *dialog_peel) {
+	dialog_type* dialog_info;
+	dialog_info = malloc_near(sizeof(dialog_type));
+	dialog_info->settings = settings;
+	dialog_info->has_peel = 0;
+	dialog_info->peel = dialog_peel;
+	if (text_rect != NULL)
+		dialog_info->text_rect = *text_rect;
+	calc_dialog_peel_rect(dialog_info);
+	if (text_rect != NULL) { 		// does not seem to be quite right; see seg009:0948 (?)
+		read_dialog_peel(dialog_info);
+	}
+	return dialog_info;
+}
+
+// seg009:0BE7
+void __pascal far calc_dialog_peel_rect(dialog_type*dialog) {
+	dialog_settings_type* settings;
+	settings = dialog->settings;
+	dialog->peel_rect.left = dialog->text_rect.left - settings->left_border;
+	dialog->peel_rect.top = dialog->text_rect.top - settings->top_border;
+	dialog->peel_rect.right = dialog->text_rect.right + settings->right_border + settings->shadow_right;
+	dialog->peel_rect.bottom = dialog->text_rect.bottom + settings->bottom_border + settings->shadow_bottom;
+}
+
+// seg009:0BB0
+void __pascal far read_dialog_peel(dialog_type *dialog) {
+	if (dialog->has_peel) {
+		if (dialog->peel == NULL) {
+			dialog->peel = read_peel_from_screen(&dialog->peel_rect);
+		}
+		dialog->has_peel = 1;
+		draw_dialog_frame(dialog);
+	}
+}
+
+// seg009:09DE
+void __pascal far draw_dialog_frame(dialog_type *dialog) {
+	dialog->settings->method_2_frame(dialog);
+}
+
+// A pointer to this function is the first field of dialog_settings (data:2944)
+// Perhaps used when replacing a dialog's text with another text (?)
+// seg009:096F
+void __pascal far add_dialog_rect(dialog_type *dialog) {
+	draw_rect(&dialog->text_rect, color_0_black);
+}
+
+// seg009:09F0
+void __pascal far dialog_method_2_frame(dialog_type *dialog) {
+	rect_type rect;
+	short shadow_right = dialog->settings->shadow_right;
+	short shadow_bottom = dialog->settings->shadow_bottom;
+	short bottom_border = dialog->settings->bottom_border;
+	short outer_border = dialog->settings->outer_border;
+	short peel_top = dialog->peel_rect.top;
+	short peel_left = dialog->peel_rect.left;
+	short peel_bottom = dialog->peel_rect.bottom;
+	short peel_right = dialog->peel_rect.right;
+	short text_top = dialog->text_rect.top;
+	short text_left = dialog->text_rect.left;
+	short text_bottom = dialog->text_rect.bottom;
+	short text_right = dialog->text_rect.right;
+	// Draw outer border
+	rect = (rect_type) { peel_top, peel_left, peel_bottom - shadow_bottom, peel_right - shadow_right };
+	draw_rect(&rect, color_0_black);
+	// Draw shadow (right)
+	rect = (rect_type) { text_top, peel_right - shadow_right, peel_bottom, peel_right };
+	draw_rect(&rect, get_text_color(0, 8 /*dialog's shadow*/, 0));
+	// Draw shadow (bottom)
+	rect = (rect_type) { peel_bottom - shadow_bottom, text_left, peel_bottom, peel_right };
+	draw_rect(&rect, get_text_color(0, 8 /*dialog's shadow*/, 0));
+	// Draw inner border (left)
+	rect = (rect_type) { peel_top + outer_border, peel_left + outer_border, text_bottom, text_left };
+	draw_rect(&rect, color_15_white);
+	// Draw inner border (top)
+	rect = (rect_type) { peel_top + outer_border, text_left, text_top, text_right + dialog->settings->right_border - outer_border };
+	draw_rect(&rect, color_15_white);
+	// Draw inner border (right)
+	rect.top = text_top;
+	rect.left =  text_right;
+	rect.bottom = text_bottom + bottom_border - outer_border; 			// (rect.right stays the same)
+	draw_rect(&rect, color_15_white);
+	// Draw inner border (bottom)
+	rect = (rect_type) { text_bottom, peel_left + outer_border, text_bottom + bottom_border - outer_border, text_right };
+	draw_rect(&rect, color_15_white);
 }
 
 // seg009:0C44
 void __pascal far show_dialog(const char *text) {
 	char string[256];
-	snprintf(string, sizeof(string), "%s\r\rPress any key to continue.", text);
-	//showmessage(string, 1, &key_test_quit);
+	snprintf(string, sizeof(string), "%s\n\nPress any key to continue.", text);
+	showmessage(string, 1, &key_test_quit);
 }
 
 // seg009:0791
@@ -1230,19 +1331,20 @@ rect_type far *__pascal shrink2_rect(rect_type far *target_rect,const rect_type 
 }
 
 // seg009:3BBA
-void __pascal far restore_peel(peel_type peel_ptr) {
+void __pascal far restore_peel(peel_type* peel_ptr) {
 	//printf("restoring peel at (x=%d, y=%d)\n", peel_ptr.rect.left, peel_ptr.rect.top); // debug
-	method_6_blit_img_to_scr(peel_ptr.peel, peel_ptr.rect.left, peel_ptr.rect.top, /*0x10*/0);
-	free_peel(&peel_ptr);
+	method_6_blit_img_to_scr(peel_ptr->peel, peel_ptr->rect.left, peel_ptr->rect.top, /*0x10*/0);
+	free_peel(peel_ptr);
 	//SDL_FreeSurface(peel_ptr.peel);
 }
 
 // seg009:3BE9
-peel_type __pascal far read_peel_from_screen(const rect_type far *rect) {
+peel_type* __pascal far read_peel_from_screen(const rect_type far *rect) {
 	// stub
-	peel_type result;
-	memset(&result, 0, sizeof(result));
-	result.rect = *rect;
+	peel_type* result;
+	result = calloc(1, sizeof(peel_type));
+	//memset(&result, 0, sizeof(result));
+	result->rect = *rect;
 #ifndef USE_ALPHA
 	SDL_Surface* peel_surface = SDL_CreateRGBSurface(0, rect->right - rect->left, rect->bottom - rect->top,
                                                      24, 0xFF, 0xFF<<8, 0xFF<<16, 0);
@@ -1253,9 +1355,9 @@ peel_type __pascal far read_peel_from_screen(const rect_type far *rect) {
 		sdlperror("SDL_CreateRGBSurface");
 		quit(1);
 	}
-	result.peel = peel_surface;
+	result->peel = peel_surface;
 	rect_type target_rect = {0, 0, rect->right - rect->left, rect->bottom - rect->top};
-	method_1_blit_rect(result.peel, current_target_surface, &target_rect, rect, 0);
+	method_1_blit_rect(result->peel, current_target_surface, &target_rect, rect, 0);
 	return result;
 }
 

--- a/types.h
+++ b/types.h
@@ -545,6 +545,27 @@ typedef struct WAV_header_type {
 } WAV_header_type;
 #endif
 
+struct dialog_type; // (declaration only)
+typedef struct dialog_settings_type {
+	void (* method_1) (struct dialog_type *dialog);
+	void (* method_2_frame) (struct dialog_type *dialog);
+	short top_border;
+	short left_border;
+	short bottom_border;
+	short right_border;
+	short shadow_bottom;
+	short shadow_right;
+	short outer_border;
+} dialog_settings_type;
+
+typedef struct dialog_type {
+	dialog_settings_type* settings;
+	rect_type text_rect;
+	rect_type peel_rect;
+	word has_peel;
+	peel_type* peel;
+} dialog_type;
+
 #pragma pack(pop)
 
 enum soundids {
@@ -974,6 +995,7 @@ enum seqtbl_sounds {
 };
 
 enum colorids {
+	color_0_black = 0,
 	color_4_red = 4,
 	color_7_grey = 7,
 	color_12_red = 12,


### PR DESCRIPTION
Added the relevant code for drawing the dialog box (converted from David's annotated V1.0 disassembly). I don't have a lot of experience with disassembly so I might have made some mistakes. In particular, I'm not too sure about `make_dialog_info()`, `seg009:08FB`. But at least it seems to work.
Notes:
- I had to change some uses of `peel_type` so that these were allocated on the heap instead of the stack, because some of the code (see `read_dialog_peel()`, `seg009:0BB0`) seemed to require that the reference to the peel persists after going out of scope.
- Changed the placement of the open potion in the copy protection level. The global variable `loaded_room` (`data:5966`) was needed so that the game knows which potion to replace.