### PR TITLE
Add option to start fullscreen, change window dimensions in the INI file

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -8,6 +8,9 @@ enable_mixer = true
 enable_fade = true
 enable_flash = true
 enable_text = true
+start_fullscreen = false
+pop_window_width = default
+pop_window_height = default
 
 [AdditionalFeatures]
 enable_quicksave = true

--- a/config.h
+++ b/config.h
@@ -23,10 +23,6 @@ The authors of this program may be contacted at http://forum.princed.org
 
 #define WINDOW_TITLE "Prince of Persia (SDLPoP) v1.16 - experimental"
 
-// Window size; game will be scaled accordingly
-#define POP_WINDOW_WIDTH 640
-#define POP_WINDOW_HEIGHT 400
-
 // Enable or disable fading.
 // Fading used to be very buggy, but now it works correctly.
 #define USE_FADE

--- a/data.h
+++ b/data.h
@@ -579,6 +579,9 @@ byte need_replay_cycle INIT(= 0);
 #endif // USE_REPLAY
 
 options_type options INIT(= {{0}});
+sbyte start_fullscreen INIT(= 0);
+word pop_window_width INIT(= 640);
+word pop_window_height INIT(= 400);
 
 #undef INIT
 #undef extern

--- a/options.c
+++ b/options.c
@@ -127,9 +127,27 @@ static int ini_callback(const char *section, const char *name, const char *value
 
     // this option has an extra allowed value, "prompt"
     if(strcasecmp(name, "use_fixes_and_enhancements") == 0) {
-        if (strcasecmp(value, "true") == 0) options.use_fixes_and_enhancements = 1;         \
+        if (strcasecmp(value, "true") == 0) options.use_fixes_and_enhancements = 1;
         else if (strcasecmp(value, "false") == 0) options.use_fixes_and_enhancements = 0;
         else if (strcasecmp(value, "prompt") == 0) options.use_fixes_and_enhancements = 2;
+    }
+
+    else if(strcasecmp(name, "start_fullscreen") == 0) {
+        if (strcasecmp(value, "true") == 0) start_fullscreen = 1;
+    }
+
+    // If custom window dimensions are specified, use those instead of the default 640x400
+    else if(strcasecmp(name, "pop_window_width") == 0) {
+        if (strcasecmp(value, "default") != 0) {
+            word new_value = (word) strtoumax(value, NULL, 0);
+            if (new_value != 0) pop_window_width = new_value;
+        }
+    }
+    else if(strcasecmp(name, "pop_window_height") == 0) {
+        if (strcasecmp(value, "default") != 0) {
+            word new_value = (word) strtoumax(value, NULL, 0);
+            if (new_value != 0) pop_window_height = new_value;
+        }
     }
 
     process_next(enable_copyprot)
@@ -171,7 +189,7 @@ void load_options() {
     if (!options.use_fixes_and_enhancements) disable_fixes_and_enhancements();
 }
 
-void show_disable_fixes_prompt() {
+void show_use_fixes_and_enhancements_prompt() {
     if (options.use_fixes_and_enhancements != 2) return;
     draw_rect(&screen_rect, 0);
     show_text(&screen_rect, 0, 0,

--- a/proto.h
+++ b/proto.h
@@ -609,7 +609,7 @@ void check_seqtable_matches_original();
 void use_default_options();
 void disable_fixes_and_enhancements();
 void load_options();
-void show_disable_fixes_prompt();
+void show_use_fixes_and_enhancements_prompt();
 
 // REPLAY.C
 #ifdef USE_REPLAY

--- a/seg000.c
+++ b/seg000.c
@@ -113,7 +113,7 @@ void __pascal far init_game_main() {
 	load_sounds(0, 43);
 	load_opt_sounds(43, 56); //added
 	hof_read();
-	show_disable_fixes_prompt(); // added
+	show_use_fixes_and_enhancements_prompt(); // added
 	start_game();
 }
 

--- a/seg009.c
+++ b/seg009.c
@@ -1845,17 +1845,17 @@ void __pascal far set_gr_mode(byte grmode) {
 
 	//SDL_EnableUNICODE(1); //deprecated
 	Uint32 flags = 0;
-	int fullscreen = check_param("full") != NULL;
-	if (fullscreen) flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+	if (!start_fullscreen) start_fullscreen = check_param("full") != NULL;
+	if (start_fullscreen) flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 	flags |= SDL_WINDOW_RESIZABLE;
 	
 	window_ = SDL_CreateWindow(WINDOW_TITLE,
 										  SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
-										  POP_WINDOW_WIDTH, POP_WINDOW_HEIGHT, flags);
+										  pop_window_width, pop_window_height, flags);
 	renderer_ = SDL_CreateRenderer(window_, -1 , SDL_RENDERER_ACCELERATED );
 	
 	// Allow us to use a consistent set of screen co-ordinates, even if the screen size changes
-	SDL_RenderSetLogicalSize(renderer_, POP_WINDOW_WIDTH, POP_WINDOW_HEIGHT);
+	SDL_RenderSetLogicalSize(renderer_, 320, 200);
 
     /* Migration to SDL2: everything is still blitted to onscreen_surface_, however:
      * SDL2 renders textures to the screen instead of surfaces; so for now, every screen
@@ -1863,16 +1863,16 @@ void __pascal far set_gr_mode(byte grmode) {
      * subsequently displayed; awaits a better refactoring!
      * The function handling the screen updates is request_screen_update()
      * */
-    onscreen_surface_ = SDL_CreateRGBSurface(0, 320, 200, 24, 0xFF, 0xFF<<8, 0xFF<<16, 0) ;
+    onscreen_surface_ = SDL_CreateRGBSurface(0, 320, 200, 24, 0xFF, 0xFF << 8, 0xFF << 16, 0) ;
 	sdl_texture_ = SDL_CreateTexture(renderer_, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING,
-												 320, 200);
+									 320, 200);
 	screen_updates_suspended = 0;
 
 	if (onscreen_surface_ == NULL) {
 		sdlperror("SDL_SetVideoMode");
 		quit(1);
 	}
-	if (fullscreen) {
+	if (start_fullscreen) {
 		SDL_ShowCursor(SDL_DISABLE);
 	}
 


### PR DESCRIPTION
This adds three options to SDLPoP.ini:
- start_fullscreen (self-explanatory: set to `true` to start fullscreen without the command-line parameter)
- pop_window_width
- pop_window_height

You can change 'pop_window_width' and 'pop_window_height' from `default` to an integer value to use a different screen size.
Original suggestion by Eugene: http://forum.princed.org/viewtopic.php?f=69&p=17290#p17251
Changed the logical rendering resolution to 320 by 200 instead of 640 by 400.
Also renamed `show_disable_fixes_prompt()` to `show_use_fixes_and_enhancements_prompt()`.