### PR TITLE
Better INI processing & new custom gameplay options

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -8,6 +8,9 @@ enable_mixer = true
 enable_fade = true
 enable_flash = true
 enable_text = true
+start_fullscreen = false
+pop_window_width = default
+pop_window_height = default
 
 [AdditionalFeatures]
 enable_quicksave = true

--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -50,4 +50,7 @@ fix_safe_landing_on_spikes = true
 start_minutes_left = default
 start_ticks_left = default
 start_hitp = default
+max_hitp_allowed = default
+saving_allowed_first_level = default
+saving_allowed_last_level = default
 allow_triggering_any_tile = false

--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -17,7 +17,7 @@ enable_quicksave = true
 enable_quicksave_penalty = true
 enable_replay = true
 
-[Gameplay]
+[Enhancements]
 use_fixes_and_enhancements = prompt
 
 ;    'prompt' --> the game will ask each time the game is launched (Default)
@@ -45,3 +45,9 @@ fix_move_after_drink = true
 fix_loose_left_of_potion = true
 fix_guard_following_through_closed_gates = true
 fix_safe_landing_on_spikes = true
+
+[CustomGameplay]
+start_minutes_left = default
+start_ticks_left = default
+start_hitp = default
+allow_triggering_any_tile = false

--- a/config.h
+++ b/config.h
@@ -23,10 +23,6 @@ The authors of this program may be contacted at http://forum.princed.org
 
 #define WINDOW_TITLE "Prince of Persia (SDLPoP) v1.16 - experimental"
 
-// Window size; game will be scaled accordingly
-#define POP_WINDOW_WIDTH 640
-#define POP_WINDOW_HEIGHT 400
-
 // Enable or disable fading.
 // Fading used to be very buggy, but now it works correctly.
 #define USE_FADE

--- a/data.h
+++ b/data.h
@@ -587,6 +587,9 @@ word pop_window_height INIT(= 400);
 word start_minutes_left INIT(= 60);
 word start_ticks_left INIT(= 719);
 word start_hitp INIT(= 3);
+word max_hitp_allowed INIT(= 10);
+word saving_allowed_first_level INIT(= 3);
+word saving_allowed_last_level INIT(= 13);
 byte allow_triggering_any_tile INIT(= 0);
 
 #undef INIT

--- a/data.h
+++ b/data.h
@@ -579,6 +579,9 @@ byte need_replay_cycle INIT(= 0);
 #endif // USE_REPLAY
 
 options_type options INIT(= {{0}});
+sbyte start_fullscreen INIT(= 0);
+word pop_window_width INIT(= 640);
+word pop_window_height INIT(= 400);
 
 #undef INIT
 #undef extern

--- a/data.h
+++ b/data.h
@@ -579,9 +579,15 @@ byte need_replay_cycle INIT(= 0);
 #endif // USE_REPLAY
 
 options_type options INIT(= {{0}});
-sbyte start_fullscreen INIT(= 0);
+byte start_fullscreen INIT(= 0);
 word pop_window_width INIT(= 640);
 word pop_window_height INIT(= 400);
+
+// Custom Gameplay settings
+word start_minutes_left INIT(= 60);
+word start_ticks_left INIT(= 719);
+word start_hitp INIT(= 3);
+byte allow_triggering_any_tile INIT(= 0);
 
 #undef INIT
 #undef extern

--- a/options.c
+++ b/options.c
@@ -116,70 +116,97 @@ int ini_load(const char *filename,
     return 0;
 }
 
+static inline int ini_process_boolean(const char* curr_name, const char* value, const char* option_name, byte* target) {
+    if(strcasecmp(curr_name, option_name) == 0) {
+        if (strcasecmp(value, "true") == 0) *target = 1;
+        else if (strcasecmp(value, "false") == 0) *target = 0;
+        return 1; // finished; don't look for more possible options that curr_name can be
+    }
+    return 0; // not the right option; should check another option_name
+}
+
+static inline int ini_process_word(const char* curr_name, const char* value, const char* option_name, word* target) {
+    if(strcasecmp(curr_name, option_name) == 0) {
+        if (strcasecmp(value, "default") != 0) {
+            word new_value = (word) strtoumax(value, NULL, 0);
+            if (new_value != 0) *target = new_value;
+        }
+        return 1; // finished; don't look for more possible options that curr_name can be
+    }
+    return 0; // not the right option; should check another option_name
+}
+
 static int ini_callback(const char *section, const char *name, const char *value)
 {
     //fprintf(stdout, "[%s] '%s'='%s'\n", section, name, value);
-    #define process(option)                                             \
-    if (strcasecmp(name, #option) == 0) {                               \
-        if (strcasecmp(value, "true") == 0) options.option = 1;         \
-        else if (strcasecmp(value, "false") == 0) options.option = 0;}
-    #define process_next(option) else process(option)
 
-    // this option has an extra allowed value, "prompt"
-    if(strcasecmp(name, "use_fixes_and_enhancements") == 0) {
-        if (strcasecmp(value, "true") == 0) options.use_fixes_and_enhancements = 1;
-        else if (strcasecmp(value, "false") == 0) options.use_fixes_and_enhancements = 0;
-        else if (strcasecmp(value, "prompt") == 0) options.use_fixes_and_enhancements = 2;
+    #define check_ini_section(section_name)    (strcasecmp(section, section_name) == 0)
+
+    // Make sure that we return successfully as soon as name matches the correct option_name
+    #define process_word(option_name, target)                           \
+    if (ini_process_word(name, value, option_name, target)) return 1;
+
+    #define process_boolean(option_name, target)                        \
+    if (ini_process_boolean(name, value, option_name, target)) return 1;
+
+    if (check_ini_section("General")) {
+        process_boolean("enable_copyprot", &options.enable_copyprot);
+        process_boolean("enable_mixer", &options.enable_mixer);
+        process_boolean("enable_fade", &options.enable_fade);
+        process_boolean("enable_flash", &options.enable_flash);
+        process_boolean("enable_text", &options.enable_text);
+        process_boolean("start_fullscreen", &start_fullscreen);
+        process_word("pop_window_width", &pop_window_width);
+        process_word("pop_window_height", &pop_window_height);
     }
 
-    else if(strcasecmp(name, "start_fullscreen") == 0) {
-        if (strcasecmp(value, "true") == 0) start_fullscreen = 1;
+    if (check_ini_section("AdditionalFeatures")) {
+        process_boolean("enable_quicksave", &options.enable_quicksave);
+        process_boolean("enable_quicksave_penalty", &options.enable_quicksave_penalty);
+        process_boolean("enable_replay", &options.enable_replay);
     }
 
-    // If custom window dimensions are specified, use those instead of the default 640x400
-    else if(strcasecmp(name, "pop_window_width") == 0) {
-        if (strcasecmp(value, "default") != 0) {
-            word new_value = (word) strtoumax(value, NULL, 0);
-            if (new_value != 0) pop_window_width = new_value;
+    if (check_ini_section("Enhancements")) {
+        if (strcasecmp(name, "use_fixes_and_enhancements") == 0) {
+            if (strcasecmp(value, "true") == 0) options.use_fixes_and_enhancements = 1;
+            else if (strcasecmp(value, "false") == 0) options.use_fixes_and_enhancements = 0;
+            else if (strcasecmp(value, "prompt") == 0) options.use_fixes_and_enhancements = 2;
+            return 1;
         }
-    }
-    else if(strcasecmp(name, "pop_window_height") == 0) {
-        if (strcasecmp(value, "default") != 0) {
-            word new_value = (word) strtoumax(value, NULL, 0);
-            if (new_value != 0) pop_window_height = new_value;
-        }
+        process_boolean("enable_crouch_after_climbing", &options.enable_crouch_after_climbing);
+        process_boolean("enable_freeze_time_during_end_music", &options.enable_freeze_time_during_end_music);
+        process_boolean("fix_gate_sounds", &options.fix_gate_sounds);
+        process_boolean("fix_two_coll_bug", &options.fix_two_coll_bug);
+        process_boolean("fix_infinite_down_bug", &options.fix_infinite_down_bug);
+        process_boolean("fix_gate_drawing_bug", &options.fix_gate_drawing_bug);
+        process_boolean("fix_bigpillar_climb", &options.fix_bigpillar_climb);
+        process_boolean("fix_jump_distance_at_edge", &options.fix_jump_distance_at_edge);
+        process_boolean("fix_edge_distance_check_when_climbing", &options.fix_edge_distance_check_when_climbing);
+        process_boolean("fix_painless_fall_on_guard", &options.fix_painless_fall_on_guard);
+        process_boolean("fix_wall_bump_triggers_tile_below", &options.fix_wall_bump_triggers_tile_below);
+        process_boolean("fix_stand_on_thin_air", &options.fix_stand_on_thin_air);
+        process_boolean("fix_press_through_closed_gates", &options.fix_press_through_closed_gates);
+        process_boolean("fix_grab_falling_speed", &options.fix_grab_falling_speed);
+        process_boolean("fix_skeleton_chomper_blood", &options.fix_skeleton_chomper_blood);
+        process_boolean("fix_move_after_drink", &options.fix_move_after_drink);
+        process_boolean("fix_loose_left_of_potion", &options.fix_loose_left_of_potion);
+        process_boolean("fix_guard_following_through_closed_gates", &options.fix_guard_following_through_closed_gates);
+        process_boolean("fix_safe_landing_on_spikes", &options.fix_safe_landing_on_spikes);
+        process_boolean("fix_wall_bump_triggers_tile_below", &options.fix_wall_bump_triggers_tile_below);
+        process_boolean("fix_wall_bump_triggers_tile_below", &options.fix_wall_bump_triggers_tile_below);
+        process_boolean("fix_wall_bump_triggers_tile_below", &options.fix_wall_bump_triggers_tile_below);
     }
 
-    process_next(enable_copyprot)
-    process_next(enable_mixer)
-    process_next(enable_fade)
-    process_next(enable_flash)
-    process_next(enable_text)
-    process_next(enable_quicksave)
-    process_next(enable_quicksave_penalty)
-    process_next(enable_replay)
-    process_next(enable_crouch_after_climbing)
-    process_next(enable_freeze_time_during_end_music)
-    process_next(fix_gate_sounds)
-    process_next(fix_two_coll_bug)
-    process_next(fix_infinite_down_bug)
-    process_next(fix_gate_drawing_bug)
-    process_next(fix_bigpillar_climb)
-    process_next(fix_jump_distance_at_edge)
-    process_next(fix_edge_distance_check_when_climbing)
-    process_next(fix_painless_fall_on_guard)
-    process_next(fix_wall_bump_triggers_tile_below)
-    process_next(fix_stand_on_thin_air)
-    process_next(fix_press_through_closed_gates)
-    process_next(fix_grab_falling_speed)
-    process_next(fix_skeleton_chomper_blood)
-    process_next(fix_move_after_drink)
-    process_next(fix_loose_left_of_potion)
-    process_next(fix_guard_following_through_closed_gates)
-    process_next(fix_safe_landing_on_spikes)
+    if (check_ini_section("CustomGameplay")) {
+        process_word("start_minutes_left", &start_minutes_left);
+        process_word("start_ticks_left", &start_ticks_left);
+        process_word("start_hitp", &start_hitp);
+        process_boolean("allow_triggering_any_tile", &allow_triggering_any_tile);
+    }
 
-    #undef process_next
-    #undef process
+    #undef process_word
+    #undef process_boolean
+    #undef check_ini_section
     return 0;
 }
 

--- a/options.c
+++ b/options.c
@@ -127,9 +127,27 @@ static int ini_callback(const char *section, const char *name, const char *value
 
     // this option has an extra allowed value, "prompt"
     if(strcasecmp(name, "use_fixes_and_enhancements") == 0) {
-        if (strcasecmp(value, "true") == 0) options.use_fixes_and_enhancements = 1;         \
+        if (strcasecmp(value, "true") == 0) options.use_fixes_and_enhancements = 1;
         else if (strcasecmp(value, "false") == 0) options.use_fixes_and_enhancements = 0;
         else if (strcasecmp(value, "prompt") == 0) options.use_fixes_and_enhancements = 2;
+    }
+
+    else if(strcasecmp(name, "start_fullscreen") == 0) {
+        if (strcasecmp(value, "true") == 0) start_fullscreen = 1;
+    }
+
+    // If custom window dimensions are specified, use those instead of the default 640x400
+    else if(strcasecmp(name, "pop_window_width") == 0) {
+        if (strcasecmp(value, "default") != 0) {
+            word new_value = (word) strtoumax(value, NULL, 0);
+            if (new_value != 0) pop_window_width = new_value;
+        }
+    }
+    else if(strcasecmp(name, "pop_window_height") == 0) {
+        if (strcasecmp(value, "default") != 0) {
+            word new_value = (word) strtoumax(value, NULL, 0);
+            if (new_value != 0) pop_window_height = new_value;
+        }
     }
 
     process_next(enable_copyprot)
@@ -171,7 +189,7 @@ void load_options() {
     if (!options.use_fixes_and_enhancements) disable_fixes_and_enhancements();
 }
 
-void show_disable_fixes_prompt() {
+void show_use_fixes_and_enhancements_prompt() {
     if (options.use_fixes_and_enhancements != 2) return;
     draw_rect(&screen_rect, 0);
     show_text(&screen_rect, 0, 0,

--- a/options.c
+++ b/options.c
@@ -201,6 +201,9 @@ static int ini_callback(const char *section, const char *name, const char *value
         process_word("start_minutes_left", &start_minutes_left);
         process_word("start_ticks_left", &start_ticks_left);
         process_word("start_hitp", &start_hitp);
+        process_word("max_hitp_allowed", &max_hitp_allowed);
+        process_word("saving_allowed_first_level", &saving_allowed_first_level);
+        process_word("saving_allowed_last_level", &saving_allowed_last_level);
         process_boolean("allow_triggering_any_tile", &allow_triggering_any_tile);
     }
 

--- a/proto.h
+++ b/proto.h
@@ -609,7 +609,7 @@ void check_seqtable_matches_original();
 void use_default_options();
 void disable_fixes_and_enhancements();
 void load_options();
-void show_disable_fixes_prompt();
+void show_use_fixes_and_enhancements_prompt();
 
 // REPLAY.C
 #ifdef USE_REPLAY

--- a/seg000.c
+++ b/seg000.c
@@ -453,7 +453,9 @@ int __pascal far process_key() {
 			}
 		break;
 		case SDL_SCANCODE_G | WITH_CTRL: // ctrl-g
-			if (current_level > 2 && current_level < 14) {
+			// CusPoP: first and last level where saving is allowed
+//			if (current_level > 2 && current_level < 14) { // original
+			if (current_level >= saving_allowed_first_level && current_level <= saving_allowed_last_level) {
 				save_game();
 			}
 		break;
@@ -1082,7 +1084,9 @@ void __pascal far draw_guard_hp(short curr_hp,short max_hp) {
 void __pascal far add_life() {
 	short hpmax = hitp_max;
 	++hpmax;
-	if (hpmax > 10) hpmax = 10;
+	// CusPop: set maximum number of hitpoints (max_hitp_allowed, default = 10)
+//	if (hpmax > 10) hpmax = 10; // original
+	if (hpmax > max_hitp_allowed) hpmax = max_hitp_allowed;
 	hitp_max = hpmax;
 	set_health_life();
 }

--- a/seg000.c
+++ b/seg000.c
@@ -113,7 +113,7 @@ void __pascal far init_game_main() {
 	load_sounds(0, 43);
 	load_opt_sounds(43, 56); //added
 	hof_read();
-	show_disable_fixes_prompt(); // added
+	show_use_fixes_and_enhancements_prompt(); // added
 	start_game();
 }
 

--- a/seg003.c
+++ b/seg003.c
@@ -38,9 +38,9 @@ void __pascal far init_game(int level) {
 	upside_down = 0;
 	resurrect_time = 0;
 	if (!dont_reset_time) {
-		rem_min = 60;
-		rem_tick = 719;
-		hitp_beg_lev = 3;
+		rem_min = start_minutes_left; 	// 60
+		rem_tick = start_ticks_left; 	// 719
+		hitp_beg_lev = start_hitp; 		// 3
 	}
 	need_level1_music = (level == 1);
 	play_level(level);

--- a/seg007.c
+++ b/seg007.c
@@ -636,7 +636,7 @@ short __pascal far trigger_1(short target_type,short room,short tilepos,short bu
 	result = -1;
 	if (target_type == tiles_4_gate) {
 		result = trigger_gate(room, tilepos, button_type);
-	} else if (target_type == tiles_16_level_door_left) {
+	} else if (target_type == tiles_16_level_door_left || allow_triggering_any_tile) { //allow_triggering_any_tile hack
 		if (curr_room_modif[tilepos] != 0) {
 			result = -1;
 		} else {

--- a/seg009.c
+++ b/seg009.c
@@ -1845,17 +1845,17 @@ void __pascal far set_gr_mode(byte grmode) {
 
 	//SDL_EnableUNICODE(1); //deprecated
 	Uint32 flags = 0;
-	int fullscreen = check_param("full") != NULL;
-	if (fullscreen) flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+	if (!start_fullscreen) start_fullscreen = check_param("full") != NULL;
+	if (start_fullscreen) flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 	flags |= SDL_WINDOW_RESIZABLE;
 	
 	window_ = SDL_CreateWindow(WINDOW_TITLE,
 										  SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
-										  POP_WINDOW_WIDTH, POP_WINDOW_HEIGHT, flags);
+										  pop_window_width, pop_window_height, flags);
 	renderer_ = SDL_CreateRenderer(window_, -1 , SDL_RENDERER_ACCELERATED );
 	
 	// Allow us to use a consistent set of screen co-ordinates, even if the screen size changes
-	SDL_RenderSetLogicalSize(renderer_, POP_WINDOW_WIDTH, POP_WINDOW_HEIGHT);
+	SDL_RenderSetLogicalSize(renderer_, 320, 200);
 
     /* Migration to SDL2: everything is still blitted to onscreen_surface_, however:
      * SDL2 renders textures to the screen instead of surfaces; so for now, every screen
@@ -1863,16 +1863,16 @@ void __pascal far set_gr_mode(byte grmode) {
      * subsequently displayed; awaits a better refactoring!
      * The function handling the screen updates is request_screen_update()
      * */
-    onscreen_surface_ = SDL_CreateRGBSurface(0, 320, 200, 24, 0xFF, 0xFF<<8, 0xFF<<16, 0) ;
+    onscreen_surface_ = SDL_CreateRGBSurface(0, 320, 200, 24, 0xFF, 0xFF << 8, 0xFF << 16, 0) ;
 	sdl_texture_ = SDL_CreateTexture(renderer_, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING,
-												 320, 200);
+									 320, 200);
 	screen_updates_suspended = 0;
 
 	if (onscreen_surface_ == NULL) {
 		sdlperror("SDL_SetVideoMode");
 		quit(1);
 	}
-	if (fullscreen) {
+	if (start_fullscreen) {
 		SDL_ShowCursor(SDL_DISABLE);
 	}
 


### PR DESCRIPTION
Follow-up to #34.

Changed the way that INI options are read. INI sections are now used to prevent too many unnecesary string comparisons. Added more sensible/flexible macros/inline functions to handle all of the options in `ini_callback()`.

SDLPoP.ini changes:
- Renamed Gameplay section to Enhancements
- Added a new section CustomGameplay with options start_minutes_left, start_ticks_left, start_hitp, allow_triggering_any_file

How to use the new options:
In SDLPoP.ini, change 'start_minutes_left' from `default` to a numerical value, e.g. `90`.
Similar for 'start_ticks_left' and 'start_hitp'.
Change 'allow_triggering_any_tile' from `false` to `true`. 

The new options were requested by SuavePrince here:
http://forum.princed.org/viewtopic.php?f=69&t=3512&start=300#p17459

For details on the original `trigger_1()` hack by @NagyD see:
http://forum.princed.org/viewtopic.php?p=13823#p13816