### PR TITLE
Remembering guard hitpoints

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -35,6 +35,7 @@ use_fixes_and_enhancements = prompt
 
 enable_crouch_after_climbing = true
 enable_freeze_time_during_end_music = true
+enable_remember_guard_hp = true
 fix_gate_sounds = true
 fix_two_coll_bug = true
 fix_infinite_down_bug = true

--- a/common.h
+++ b/common.h
@@ -32,6 +32,7 @@ extern "C" {
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <stdbool.h>
 
 #include "config.h"
 #include "types.h"

--- a/config.h
+++ b/config.h
@@ -72,6 +72,9 @@ The authors of this program may be contacted at http://forum.princed.org
 //      5 = wall including blue line; 50 = no blue
 #define USE_FAKE_TILES
 
+// Allow guard hitpoints not resetting to their default (maximum) value when re-entering the room
+#define REMEMBER_GUARD_HP
+
 // Bugfixes:
 
 // The mentioned tricks can be found here: http://www.popot.org/documentation.php?doc=Tricks

--- a/options.c
+++ b/options.c
@@ -34,6 +34,7 @@ void use_default_options() {
     options.enable_replay = 1;
     options.enable_crouch_after_climbing = 1;
     options.enable_freeze_time_during_end_music = 1;
+    options.enable_remember_guard_hp = 1;
     options.fix_gate_sounds = 1;
     options.fix_two_coll_bug = 1;
     options.fix_infinite_down_bug = 1;
@@ -56,6 +57,7 @@ void use_default_options() {
 void disable_fixes_and_enhancements() {
     options.enable_crouch_after_climbing = 0;
     options.enable_freeze_time_during_end_music = 0;
+    options.enable_remember_guard_hp = 0;
     options.fix_gate_sounds = 0;
     options.fix_two_coll_bug = 0;
     options.fix_infinite_down_bug = 0;
@@ -231,6 +233,7 @@ static int ini_callback(const char *section, const char *name, const char *value
         }
         process_boolean("enable_crouch_after_climbing", &options.enable_crouch_after_climbing);
         process_boolean("enable_freeze_time_during_end_music", &options.enable_freeze_time_during_end_music);
+        process_boolean("enable_remember_guard_hp", &options.enable_remember_guard_hp);
         process_boolean("fix_gate_sounds", &options.fix_gate_sounds);
         process_boolean("fix_two_coll_bug", &options.fix_two_coll_bug);
         process_boolean("fix_infinite_down_bug", &options.fix_infinite_down_bug);

--- a/proto.h
+++ b/proto.h
@@ -31,6 +31,7 @@ void __pascal far load_sounds(int min_sound,int max_sound);
 void __pascal far load_opt_sounds(int first,int last);
 void __pascal far load_lev_spr(int level);
 void __pascal far load_level();
+void reset_level_unused_fields(bool loading_clean_level);
 int __pascal far play_kid_frame();
 void __pascal far play_guard_frame();
 void __pascal far check_the_end();

--- a/seg000.c
+++ b/seg000.c
@@ -292,6 +292,7 @@ int quick_save() {
 void restore_room_after_quick_load() {
 	int temp1 = curr_guard_color;
 	int temp2 = next_level;
+	reset_level_unused_fields(false);
 	load_lev_spr(current_level);
 	curr_guard_color = temp1;
 	next_level = temp2;
@@ -942,6 +943,33 @@ void __pascal far load_level() {
 	close_dat(dathandle);
 
 	alter_mods_allrm();
+	reset_level_unused_fields(true); // added
+}
+
+void reset_level_unused_fields(bool loading_clean_level) {
+	// Entirely unused fields in the level format: reset to zero for now
+	// They can be repurposed to add new stuff to the level format in the future
+	memset(level.roomxs, 0, COUNT(level.roomxs));
+	memset(level.roomys, 0, COUNT(level.roomys));
+	memset(level.fill_1, 0, COUNT(level.fill_1));
+	memset(level.fill_2, 0, COUNT(level.fill_2));
+	memset(level.fill_3, 0, COUNT(level.fill_3));
+
+	// For these fields, only use the bits that are actually used, and set the rest to zero.
+	// Good for repurposing the unused bits in the future.
+	int i;
+	for (i = 0; i < level.used_rooms; ++i) {
+		//level.guards_dir[i]   &= 0x01; // 1 bit in use
+		level.guards_skill[i] &= 0x0F; // 4 bits in use
+	}
+
+	// In savestates, additional information may be stored (e.g. remembered guard hp) - should not reset this then!
+	if (loading_clean_level) {
+		for (i = 0; i < level.used_rooms; ++i) {
+			level.guards_color[i] &= 0x0F; // 4 bits in use (other 4 bits repurposed as remembered guard hp)
+		}
+	}
+
 }
 
 // seg000:0EA8

--- a/seg002.c
+++ b/seg002.c
@@ -122,6 +122,12 @@ void __pascal far enter_guard() {
 	} else {
 		curr_guard_color = 0;
 	}
+
+	#ifdef REMEMBER_GUARD_HP
+	int remembered_hp = (curr_guard_color & 0xF0) >> 4;
+    #endif
+	curr_guard_color &= 0x0F; // added; only least significant 4 bits are used for guard color
+
 	// level 3 has skeletons with infinite lives
 	if (current_level == 3) {
 		Char.charid = charid_4_skeleton;
@@ -156,6 +162,10 @@ void __pascal far enter_guard() {
 		guard_refrac = 0;
 		is_guard_notice = 0;
 		get_guard_hp();
+		#ifdef REMEMBER_GUARD_HP
+		if (options.enable_remember_guard_hp && remembered_hp > 0)
+			guardhp_delta = guardhp_curr = (word) remembered_hp;
+		#endif
 	}
 	Char.fall_y = 0;
 	Char.fall_x = 0;
@@ -201,7 +211,13 @@ void __pascal far leave_guard() {
 	// arrays are indexed 0..23 instead of 1..24
 	room_minus_1 = Guard.room - 1;
 	level.guards_tile[room_minus_1] = get_tilepos(0, Guard.curr_row);
-	level.guards_color[room_minus_1] = curr_guard_color;
+
+	level.guards_color[room_minus_1] = curr_guard_color & 0x0F; // restriction to 4 bits added
+#ifdef REMEMBER_GUARD_HP
+	if (options.enable_remember_guard_hp && guardhp_curr < 16) // can remember 1..15 hp
+		level.guards_color[room_minus_1] |= (guardhp_curr << 4);
+#endif
+
 	level.guards_x[room_minus_1] = Guard.x;
 	level.guards_dir[room_minus_1] = Guard.direction;
 	level.guards_skill[room_minus_1] = guard_skill;

--- a/types.h
+++ b/types.h
@@ -1058,6 +1058,7 @@ typedef union options_type {
 		byte fix_safe_landing_on_spikes;
 
 		byte use_correct_aspect_ratio;
+		byte enable_remember_guard_hp;
 	};
 } options_type;
 


### PR DESCRIPTION
This adds a way for guard hitpoints to not get reset when re-entering a room with a guard (added a new option `enable_remember_guard_hp` in the Enhancements section of `SDLPoP.ini`)
Added a function that resets the unused fields and bits in the level format to zero (may be useful for forward compatibility, should we want to add things to the level format / savestate format in the future)
Added an `#include` for `stdbool.h`.