### PR TITLE
Updated CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,2 @@
+cmake_minimum_required(VERSION 3.1)
+add_subdirectory(source)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -15,7 +15,7 @@ if (WIN32)
 endif(WIN32)
 
 # have CMake output binaries to the directory that contains the source files
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${SDLPoP_SOURCE_DIR}")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${SDLPoP_SOURCE_DIR}/..")
 
 # if SDL_2, SDL2_image and SDL2_mixer are not in the toolchain/build environment, specify /include and /lib paths:
 


### PR DESCRIPTION
This updates CMakeLists.txt so that it works with the changed folder layout.
It turns out that CMake expects the file `CMakeLists.txt` to be present in multiple places. So I added another `CMakeLists.txt` in the root folder (all it does is link to the `/source` subdirectory).

I also moved the data files to the `/bin` folder (so the executable can find the game data). And moved the `/doc` folder as well.