### PR TITLE
New movement fixes

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -52,6 +52,9 @@ fix_move_after_drink = true
 fix_loose_left_of_potion = true
 fix_guard_following_through_closed_gates = true
 fix_safe_landing_on_spikes = true
+fix_glide_through_wall = true
+fix_drop_through_tapestry = true
+fix_land_against_gate_or_tapestry = true
 
 [CustomGameplay]
 start_minutes_left = default

--- a/config.h
+++ b/config.h
@@ -131,6 +131,16 @@ The authors of this program may be contacted at http://forum.princed.org
 // When landing on the edge of a spikes tile, it is considered safe. (Trick 65)
 #define FIX_SAFE_LANDING_ON_SPIKES
 
+// The kid may glide through walls after turning around while running (especially when weightless).
+#define FIX_GLIDE_THROUGH_WALL
+
+// The kid can drop down through a closed gate, when there is a tapestry (doortop) above the gate.
+#define FIX_DROP_THROUGH_TAPESTRY
+
+// When dropping down and landing right in front of a wall, the entire landing animation should normally play.
+// However, when falling against a closed gate or a tapestry(+floor) tile, the animation aborts.
+// (The game considers these tiles floor tiles; so it mistakenly assumes that no x-position adjustment is needed)
+#define FIX_LAND_AGAINST_GATE_OR_TAPESTRY
 
 // Debug features:
 

--- a/options.c
+++ b/options.c
@@ -51,6 +51,9 @@ void use_default_options() {
     options.fix_loose_left_of_potion = 1;
     options.fix_guard_following_through_closed_gates = 1;
     options.fix_safe_landing_on_spikes = 1;
+    options.fix_glide_through_wall = 1;
+    options.fix_drop_through_tapestry = 1;
+    options.fix_land_against_gate_or_tapestry = 1;
 }
 
 void disable_fixes_and_enhancements() {
@@ -73,6 +76,9 @@ void disable_fixes_and_enhancements() {
     options.fix_loose_left_of_potion = 0;
     options.fix_guard_following_through_closed_gates = 0;
     options.fix_safe_landing_on_spikes = 0;
+    options.fix_glide_through_wall = 0;
+    options.fix_drop_through_tapestry = 0;
+    options.fix_land_against_gate_or_tapestry = 0;
 }
 
 // .ini file parser adapted from https://gist.github.com/OrangeTide/947070
@@ -248,9 +254,9 @@ static int ini_callback(const char *section, const char *name, const char *value
         process_boolean("fix_loose_left_of_potion", &options.fix_loose_left_of_potion);
         process_boolean("fix_guard_following_through_closed_gates", &options.fix_guard_following_through_closed_gates);
         process_boolean("fix_safe_landing_on_spikes", &options.fix_safe_landing_on_spikes);
-        process_boolean("fix_wall_bump_triggers_tile_below", &options.fix_wall_bump_triggers_tile_below);
-        process_boolean("fix_wall_bump_triggers_tile_below", &options.fix_wall_bump_triggers_tile_below);
-        process_boolean("fix_wall_bump_triggers_tile_below", &options.fix_wall_bump_triggers_tile_below);
+        process_boolean("fix_glide_through_wall", &options.fix_glide_through_wall);
+        process_boolean("fix_drop_through_tapestry", &options.fix_drop_through_tapestry);
+        process_boolean("fix_land_against_gate_or_tapestry", &options.fix_land_against_gate_or_tapestry);
     }
 
     if (check_ini_section("CustomGameplay")) {

--- a/types.h
+++ b/types.h
@@ -1058,6 +1058,9 @@ typedef union options_type {
 		byte fix_safe_landing_on_spikes;
 
 		byte use_correct_aspect_ratio;
+		byte fix_glide_through_wall;
+		byte fix_drop_through_tapestry;
+		byte fix_land_against_gate_or_tapestry;
 	};
 } options_type;
 


### PR DESCRIPTION
This adds optional fixes for a few movement/collision glitches:
- FIX_GLIDE_THROUGH_WALL: Fixes the kid being able to glide sideways through the top sections of walls/tapestries while in freefall. (see [Trick 49](http://www.popot.org/documentation.php?doc=TricksPage2#49), [Trick 66](http://www.popot.org/documentation.php?doc=TricksPage2#66))
- FIX_DROP_THROUGH_TAPESTRY: Fixes the kid dropping through tiles when dropping down from a tapestry. (see [Trick 44](http://www.popot.org/documentation.php?doc=TricksPage2#44))
- FIX_LAND_AGAINST_GATE_OR_TAPESTRY: Fixes the landing animation aborting when landing against a gate or tapestry+floor instead of a wall