### PR TITLE
Removed duplicate const to avoid warnings in default gcc settings on …

### DIFF
--- a/replay.c
+++ b/replay.c
@@ -48,7 +48,7 @@ byte special_move = 0;
 
 FILE* replay_fp;
 #define REPLAY_DEFAULT_FILENAME "REPLAY_001.P1R"
-const char const replay_version[] = "V1.16b3 ";
+const char replay_version[] = "V1.16b3 ";
 char replay_control[] = "........";
 byte replay_file_open = 0;
 word current_replay_number = 0;
@@ -61,7 +61,7 @@ size_t savestate_size = 0;
 // These are defined in seg000.c:
 typedef int process_func_type(void* data, size_t data_size);
 extern int quick_process(process_func_type process_func);
-extern const char const quick_version[9];
+extern const char quick_version[9];
 extern char quick_control[9];
 
 byte open_replay_file(const char *filename) {

--- a/seg000.c
+++ b/seg000.c
@@ -273,8 +273,8 @@ int quick_process(process_func_type process_func) {
 	return ok;
 }
 
-const char* const quick_file = "QUICKSAVE.SAV";
-const char const quick_version[] = "V1.16b4 ";
+const char* quick_file = "QUICKSAVE.SAV";
+const char quick_version[] = "V1.16b4 ";
 char quick_control[] = "........";
 
 int quick_save() {

--- a/seg001.c
+++ b/seg001.c
@@ -731,7 +731,7 @@ void __pascal far show_hof() {
 	// stub
 }
 
-static const char const * hof_path = "PRINCE.HOF";
+static const char* hof_path = "PRINCE.HOF";
 
 // seg001:0F17
 void __pascal far hof_write() {

--- a/seg008.c
+++ b/seg008.c
@@ -889,7 +889,7 @@ void __pascal far draw_back_fore(int which_table,int index) {
 	back_table_type* table_entry;
 	if (which_table == 0) {
 		table_entry = &backtable[index];
-	} else if (which_table == 1) {
+	} else /* if (which_table == 1) this is always true */ {
 		table_entry = &foretable[index];
 	}
 	image = mask = get_image(table_entry->chtab_id, table_entry->id);

--- a/seg009.c
+++ b/seg009.c
@@ -1586,7 +1586,7 @@ const int max_sound_id = 58;
 char** sound_names = NULL;
 
 void load_sound_names() {
-	const char const * names_path = "data/music/names.txt";
+	const char* names_path = "data/music/names.txt";
 	if (sound_names != NULL) return;
 	FILE* fp = fopen(names_path,"rt");
 	if (fp==NULL) return;


### PR DESCRIPTION
…OSX. Commented an always-true if.

There are lots of duplicated const in the source, this is the first time I've seen that, is there a reason? Does it work to tell the compiler that the second const belongs to the pointer? In my gcc, compiling with -Wall it throws duplicate 'const' declaration specifier [-Wduplicate-decl-specifier].