### PR TITLE
Visual C++ (NMake) support

### DIFF
--- a/NMakefile
+++ b/NMakefile
@@ -1,0 +1,24 @@
+
+OBJ = main.obj data.obj seg000.obj seg001.obj seg002.obj seg003.obj seg004.obj seg005.obj seg006.obj seg007.obj seg008.obj seg009.obj seqtbl.obj replay.obj options.obj
+
+sdl = "..\SDL2-2.0.4"
+LIBS = $(sdl)\lib\x86\SDL2main.lib $(sdl)\lib\x86\SDL2.lib $(sdl)\lib\x86\SDL2_image.lib $(sdl)\lib\x86\SDL2_mixer.lib
+cc = cl /c
+link = link /subsystem:windows
+
+!IF "$(DEBUG)" == "yes"
+cflags = $(cflags) /MDd /Od
+!ELSE
+cflags = $(cflags) /MD /O2
+!ENDIF
+
+all: prince.exe
+
+.c.obj:
+	$(cc) $(cdebug) $(cflags) $(cvars) /I. /I$(sdl)\include $<
+
+prince.exe: $(OBJ)
+	$(link) $(ldebug) $(conflags) -out:prince.exe $(conlibs) $(OBJ) $(LIBS)
+
+clean:
+	del *.obj prince.exe

--- a/common.h
+++ b/common.h
@@ -31,7 +31,12 @@ extern "C" {
 #include <fcntl.h>
 #include <string.h>
 #include <sys/stat.h>
+#ifdef _MSC_VER
+#include <io.h>
+#include "unistd_win.h"
+#else
 #include <unistd.h>
+#endif
 #include <stdbool.h>
 
 #include "config.h"

--- a/config.h
+++ b/config.h
@@ -21,6 +21,12 @@ The authors of this program may be contacted at http://forum.princed.org
 #ifndef CONFIG_H
 #define CONFIG_H
 
+// WINDOWS overrides
+#ifdef _MSC_VER
+#define strncasecmp _strnicmp
+#define strcasecmp _stricmp
+#endif
+
 #define WINDOW_TITLE "Prince of Persia (SDLPoP) v1.16"
 
 // Enable or disable fading.

--- a/unistd_win.h
+++ b/unistd_win.h
@@ -1,0 +1,9 @@
+#pragma once
+#ifndef _UNISTD_H
+#define _UNISTD_H    1
+
+#define F_OK    0       /* Test for existence.  */
+
+#define access _access
+
+#endif


### PR DESCRIPTION
- added unistd_win.h to support windows-specific differences from GNU
- added NMakefile for nmake to use to build the project
- updated common.h and config.h for minor windows-specifics such as
including the unistd_win.h when compiling with VC++

I think this works ok, but I haven't tested it thoroughly