### PR TITLE
Loading mods from mods/ directory, with custom INI settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ QUICKSAVE.SAV
 # PoP recorded gameplay (replay)
 *.P1R
 
+# PoP custom levelsets
+mods/*/
+
 # Object files
 *.o
 *.ko

--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -31,11 +31,11 @@ enable_quicksave_penalty = true
 enable_replay = true
 
 [Enhancements]
-use_fixes_and_enhancements = prompt
+use_fixes_and_enhancements = false
 
-;    'prompt' --> the game will ask each time the game is launched (Default)
+;    'prompt' --> the game will ask each time the game is launched
 ;    'true'   --> fixes and enhancements are used
-;    'false'  --> fixes and enhancements are not used
+;    'false'  --> fixes and enhancements are not used (Default)
 ;
 ; Below, you can pick which fixes/enhancements will be active:
 

--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -19,6 +19,12 @@ pop_window_width = default
 pop_window_height = default
 use_correct_aspect_ratio = false
 
+; You can choose which levels to play using the 'levelset' option:
+;    'original'       --> play the original levels (Default)
+;    'Your Mod Name'  --> play a custom levelset (the custom files must be in a directory "mods/Your Mod Name/")
+
+levelset = original
+
 [AdditionalFeatures]
 enable_quicksave = true
 enable_quicksave_penalty = true

--- a/data.h
+++ b/data.h
@@ -582,6 +582,8 @@ extern options_type options INIT(= {{0}});
 extern byte start_fullscreen INIT(= 0);
 extern word pop_window_width INIT(= 640);
 extern word pop_window_height INIT(= 400);
+extern byte use_custom_levelset INIT(= 0);
+extern char levelset_name[256];
 
 // Custom Gameplay settings
 extern word start_minutes_left INIT(= 60);

--- a/doc/Readme.txt
+++ b/doc/Readme.txt
@@ -157,6 +157,10 @@ A:
 Since version 1.02, the game supports LEVELS.DAT, and since version 1.03, the game can use all .DAT files.
 You can either copy the modified .DAT files to the folder of the game, or the game to the mod's folder.
 
+Since version 1.17, the game can also load from mod folders that have been placed in the mods/ directory.
+To choose which mod to play, open SDLPoP.ini and change the 'levelset' option to the name of the mod folder.
+If you use this method, only the files different from the original V1.0 data are required in the mod's folder.
+
 Another way is to start the game while the current directory is the mod's directory.
 You can do this from the command line, or with batch files / shell scripts.
 This is useful if you want to compare the behavior of this port and the original DOS version (to find bugs).

--- a/doc/mod.ini
+++ b/doc/mod.ini
@@ -1,0 +1,89 @@
+; ========================
+; SDLPoP mod configuration
+; ========================
+
+; This is an example configuration file for custom levelsets loaded with SDLPoP.
+
+; To use, place a copy of this file in the mod's directory ("mods/Your Mod Name/").
+; For general information on how you can use mods with SDLPoP, see Readme.txt.
+
+; Lines starting with a semicolon (";") are comment lines and are ignored by SDLPoP.
+; They are used to document the available customization options.
+
+; "default" is a valid setting for any option.
+
+; NOTE: In this example file, the available options were all disabled, so they do not
+;       immediately replace the settings in SDLPoP.ini.
+;       To re-enable an option, simply delete the semicolon in front of that option.
+
+
+[General]
+;enable_copyprot = false
+
+[AdditionalFeatures]
+;enable_quicksave = true
+;enable_quicksave_penalty = true
+
+[Enhancements]
+;use_fixes_and_enhancements = false
+
+;    'prompt' --> the game will ask each time the game is launched (Default)
+;    'true'   --> fixes and enhancements are used
+;    'false'  --> fixes and enhancements are not used
+;
+; Below, you can pick which fixes/enhancements will be active:
+
+;enable_crouch_after_climbing = true
+;enable_freeze_time_during_end_music = true
+;enable_remember_guard_hp = true
+;fix_gate_sounds = true
+;fix_two_coll_bug = true
+;fix_infinite_down_bug = true
+;fix_gate_drawing_bug = false
+;fix_bigpillar_climb = false
+;fix_jump_distance_at_edge = true
+;fix_edge_distance_check_when_climbing = true
+;fix_painless_fall_on_guard = true
+;fix_wall_bump_triggers_tile_below = true
+;fix_stand_on_thin_air = true
+;fix_press_through_closed_gates = true
+;fix_grab_falling_speed = true
+;fix_skeleton_chomper_blood = true
+;fix_move_after_drink = true
+;fix_loose_left_of_potion = true
+;fix_guard_following_through_closed_gates = true
+;fix_safe_landing_on_spikes = true
+;fix_glide_through_wall = true
+;fix_drop_through_tapestry = true
+;fix_land_against_gate_or_tapestry = true
+
+[CustomGameplay]
+;start_minutes_left = default
+;start_ticks_left = default
+;start_hitp = default
+;max_hitp_allowed = default
+;saving_allowed_first_level = default
+;saving_allowed_last_level = default
+;allow_triggering_any_tile = false
+
+; The following customization options can be used in all level sections:
+; level_type = 0: dungeon, 1: palace
+; level_color = 0: colors from VDUNGEON.DAT/VPALACE.DAT, >0: colors from PRINCE.DAT (You need a PRINCE.DAT from 1.3 or 1.4 for this.)
+; guard_type = 0: guard, 1: fat, 2: skel, 3: vizier, 4: shadow
+; guard_hp = Base hitpoints for guards on this level.
+[Level 0] ; demo
+[Level 1]
+[Level 2]
+[Level 3]
+[Level 4]
+[Level 5]
+[Level 6]
+[Level 7]
+[Level 8]
+[Level 9]
+[Level 10]
+[Level 11]
+[Level 12]
+[Level 13] ; Jaffar
+[Level 14] ; princess
+[Level 15] ; potions

--- a/mods/mods.txt
+++ b/mods/mods.txt
@@ -1,0 +1,20 @@
+Playing custom levelsets with SDLPoP
+====================================
+
+1. Place the folder with the mod's files inside this folder (the "mods/" directory).
+
+2. Make sure that the name of the mod's folder is correct.
+   For example: 
+
+   mods/Prince4D/
+
+3. Open SDLPoP.ini and change the value of the 'levelset' option to the name of the mod.
+   For example: 
+
+   levelset = Prince4D
+
+4. Save the changes to SDLPoP.ini, launch the game and play!
+
+
+
+N.B.: In the mod's directory, only the data files that are different from the original game (V1.0) are needed.

--- a/options.c
+++ b/options.c
@@ -193,7 +193,7 @@ static inline int ini_process_byte(const char* curr_name, const char* value, con
     return 0; // not the right option; should check another option_name
 }
 
-static int ini_callback(const char *section, const char *name, const char *value)
+static int global_ini_callback(const char *section, const char *name, const char *value)
 {
     //fprintf(stdout, "[%s] '%s'='%s'\n", section, name, value);
 
@@ -295,16 +295,34 @@ static int ini_callback(const char *section, const char *name, const char *value
             // TODO: warning?
         }
     }
+    return 0;
+}
 
-    #undef process_word
-    #undef process_boolean
-    #undef check_ini_section
+// Callback for a mod-specific INI configuration (that may overrule SDLPoP.ini for SOME but not all options):
+static int mod_ini_callback(const char *section, const char *name, const char *value) {
+    if (check_ini_section("Enhancements") || check_ini_section("CustomGameplay") ||
+            strncasecmp(section, "Level ", 6) == 0 ||
+            strcasecmp(name, "enable_copyprot") == 0 ||
+            strcasecmp(name, "enable_quicksave") == 0 ||
+            strcasecmp(name, "enable_quicksave_penalty") == 0 ||
+            strcasecmp(name, "enable_copyprot") == 0
+            ) {
+        global_ini_callback(section, name, value);
+    }
     return 0;
 }
 
 void load_options() {
     use_default_options();
-    ini_load("SDLPoP.ini", ini_callback);
+    ini_load("SDLPoP.ini", global_ini_callback); // global configuration
+
+    // load mod-specific INI configuration
+    if (use_custom_levelset) {
+        char filename[256];
+        snprintf(filename, sizeof(filename), "mods/%s/%s", levelset_name, "mod.ini");
+        ini_load(filename, mod_ini_callback);
+    }
+
     if (!options.use_fixes_and_enhancements) disable_fixes_and_enhancements();
 }
 

--- a/options.c
+++ b/options.c
@@ -222,6 +222,16 @@ static int ini_callback(const char *section, const char *name, const char *value
         process_word("pop_window_width", &pop_window_width, NULL);
         process_word("pop_window_height", &pop_window_height, NULL);
         process_boolean("use_correct_aspect_ratio", &options.use_correct_aspect_ratio);
+
+        if (strcasecmp(name, "levelset") == 0) {
+            if (value[0] == '\0' || strcasecmp(value, "original") == 0 || strcasecmp(value, "default") == 0) {
+                use_custom_levelset = 0;
+            } else {
+                use_custom_levelset = 1;
+                strcpy(levelset_name, value);
+            }
+            return 1;
+        }
     }
 
     if (check_ini_section("AdditionalFeatures")) {

--- a/seg009.c
+++ b/seg009.c
@@ -116,7 +116,19 @@ int __pascal far pop_wait(int timer_index,int time) {
 
 // seg009:0F58
 dat_type *__pascal open_dat(const char *filename,int drive) {
-	FILE* fp = fopen(filename, "rb");
+	FILE* fp = NULL;
+	if (!use_custom_levelset) {
+		fp = fopen(filename, "rb");
+	}
+	else {
+		char filename_mod[256];
+		// before checking the root directory, first try mods/MODNAME/
+		snprintf(filename_mod, sizeof(filename_mod), "mods/%s/%s", levelset_name, filename);
+		fp = fopen(filename_mod, "rb");
+		if (fp == NULL) {
+			fp = fopen(filename, "rb");
+		}
+	}
 	dat_header_type dat_header;
 	dat_table_type* dat_table = NULL;
 
@@ -2009,8 +2021,21 @@ void load_from_opendats_metadata(int resource_id, const char* extension, FILE** 
 		} else {
 			// If it's a directory:
 			snprintf(image_filename,sizeof(image_filename),"data/%s/res%d.%s",pointer->filename, resource_id, extension);
-			//printf("loading (binary) %s",image_filename);
-			fp = fopen(image_filename, "rb");
+			if (!use_custom_levelset) {
+				//printf("loading (binary) %s",image_filename);
+				fp = fopen(image_filename, "rb");
+			}
+			else {
+				char image_filename_mod[256];
+				// before checking data/, first try mods/MODNAME/data/
+				snprintf(image_filename_mod, sizeof(image_filename_mod), "mods/%s/%s", levelset_name, image_filename);
+				//printf("loading (binary) %s",image_filename_mod);
+				fp = fopen(image_filename_mod, "rb");
+				if (fp == NULL) {
+					fp = fopen(image_filename, "rb");
+				}
+			}
+
 			if (fp != NULL) {
 				struct stat buf;
 				if (fstat(fileno(fp), &buf) == 0) {


### PR DESCRIPTION
This adds the ability to easily load levelsets from their own separate directories
- Mods can be installed into their own separate directories by putting the modified data files in a mod subdirectory under `mods/`.
- You can choose which mod to play from SDLPoP.ini, using the option `levelset`
- Custom INI settings can be loaded directly from a mod directory (filename `mod.ini`). The options in `mod.ini` are allowed to override those specified in `SDLPoP.ini`.
- Documentation: added an example mod.ini to `doc/`, added instructions on how to use in `mods/mods.txt` and added a small paragraph about loading from mod folders to `Readme.txt`.
- Changed the default of `use_fixes_and_enhancements` to `false`, because it is now easier for mod authors to override the default setting (see reasoning for this proposal in the commit notes)

(I previous added these changes to the script branch (#57). However, perhaps it makes sense to deal with these independently, so I extracted the changes)