### PR TITLE
Added missing color ids, using the names of the default EGA palette

### DIFF
--- a/seg000.c
+++ b/seg000.c
@@ -1412,7 +1412,7 @@ const rect_type rect_titles = {106,24,195,296};
 void __pascal far show_title() {
 	word textcolor;
 	load_opt_sounds(sound_50_story_2_princess, sound_55_story_1_absence); // main theme, story, princess door
-	textcolor = get_text_color(15, color_15_white, 0x800);
+	textcolor = get_text_color(15, color_15_brightwhite, 0x800);
 	dont_reset_time = 0;
 	if(offscreen_surface) free_surface(offscreen_surface); // missing in original
 	offscreen_surface = make_offscreen_buffer(&screen_rect);

--- a/seg001.c
+++ b/seg001.c
@@ -579,7 +579,7 @@ void __pascal far end_sequence() {
 	load_title_images(0);
 	current_target_surface = offscreen_surface;
 	draw_image_2(0 /*story frame*/, chtab_title40, 0, 0, 0);
-	draw_image_2(3 /*The tyrant Jaffar*/, chtab_title40, 24, 25, get_text_color(15, color_15_white, 0x800));
+	draw_image_2(3 /*The tyrant Jaffar*/, chtab_title40, 24, 25, get_text_color(15, color_15_brightwhite, 0x800));
 	fade_in_2(offscreen_surface, 0x800);
 	pop_wait(timer_0, 900);
 	start_timer(timer_0, 240);

--- a/seg002.c
+++ b/seg002.c
@@ -1094,7 +1094,7 @@ void __pascal far autocontrol_shadow_level12() {
 	}
 	if (char_opp_dist() < 10) {
 		// unite with the shadow
-		flash_color = color_15_white; // white
+		flash_color = color_15_brightwhite; // white
 		flash_time = 18;
 		// get an extra HP for uniting the shadow
 		add_life();

--- a/seg003.c
+++ b/seg003.c
@@ -647,7 +647,7 @@ int __pascal far flash_if_hurt() {
 		do_flash_no_delay(flash_color); // don't add delay to the flash
 		return 1;
 	} else if (hitp_delta < 0) {
-		do_flash_no_delay(color_12_red); // red
+		do_flash_no_delay(color_12_brightred); // red
 		return 1;
 	}
 	return 0; // not flashed

--- a/seg006.c
+++ b/seg006.c
@@ -1620,7 +1620,7 @@ void __pascal far proc_get_object() {
 	if (pickup_obj_type == -1) {
 		have_sword = -1;
 		play_sound(sound_37_victory); // get sword
-		flash_color = color_14_yellow;
+		flash_color = color_14_brightyellow;
 		flash_time = 8;
 	} else {
 		switch (--pickup_obj_type) {
@@ -1692,7 +1692,7 @@ void __pascal far on_guard_killed() {
 		demo_index = demo_time = 0;
 	} else if (current_level == 13) {
 		// Jaffar's level: flash
-		flash_color = color_15_white; // white
+		flash_color = color_15_brightwhite; // white
 		flash_time = 18;
 		is_show_time = 1;
 		leveldoor_open = 2;
@@ -1798,7 +1798,7 @@ void __pascal far check_killed_shadow() {
 		if ((Char.charid | Opp.charid) == charid_1_shadow &&
 			Char.alive < 0 && Opp.alive >= 0
 		) {
-			flash_color = color_15_white; // white
+			flash_color = color_15_brightwhite; // white
 			flash_time = 5;
 			take_hp(100);
 		}

--- a/seg009.c
+++ b/seg009.c
@@ -1045,7 +1045,7 @@ int __pascal far showmessage(char far *text,int arg_4,void far *arg_0) {
 	//saved_font_ptr = current_target_surface->ptr_font;
 	//current_target_surface->ptr_font = ptr_font;
 	shrink2_rect(&rect, &copyprot_dialog->text_rect, 2, 1);
-	show_text_with_color(&rect, 0, 0, text, color_15_white);
+	show_text_with_color(&rect, 0, 0, text, color_15_brightwhite);
 	screen_updates_suspended = 0;
 	request_screen_update();
 	//textstate.ptr_font = saved_font_ptr;
@@ -1131,24 +1131,24 @@ void __pascal far dialog_method_2_frame(dialog_type *dialog) {
 	draw_rect(&rect, color_0_black);
 	// Draw shadow (right)
 	rect = (rect_type) { text_top, peel_right - shadow_right, peel_bottom, peel_right };
-	draw_rect(&rect, get_text_color(0, color_8_darkgrey /*dialog's shadow*/, 0));
+	draw_rect(&rect, get_text_color(0, color_8_darkgray /*dialog's shadow*/, 0));
 	// Draw shadow (bottom)
 	rect = (rect_type) { peel_bottom - shadow_bottom, text_left, peel_bottom, peel_right };
-	draw_rect(&rect, get_text_color(0, color_8_darkgrey /*dialog's shadow*/, 0));
+	draw_rect(&rect, get_text_color(0, color_8_darkgray /*dialog's shadow*/, 0));
 	// Draw inner border (left)
 	rect = (rect_type) { peel_top + outer_border, peel_left + outer_border, text_bottom, text_left };
-	draw_rect(&rect, color_15_white);
+	draw_rect(&rect, color_15_brightwhite);
 	// Draw inner border (top)
 	rect = (rect_type) { peel_top + outer_border, text_left, text_top, text_right + dialog->settings->right_border - outer_border };
-	draw_rect(&rect, color_15_white);
+	draw_rect(&rect, color_15_brightwhite);
 	// Draw inner border (right)
 	rect.top = text_top;
 	rect.left =  text_right;
 	rect.bottom = text_bottom + bottom_border - outer_border; 			// (rect.right stays the same)
-	draw_rect(&rect, color_15_white);
+	draw_rect(&rect, color_15_brightwhite);
 	// Draw inner border (bottom)
 	rect = (rect_type) { text_bottom, peel_left + outer_border, text_bottom + bottom_border - outer_border, text_right };
-	draw_rect(&rect, color_15_white);
+	draw_rect(&rect, color_15_brightwhite);
 }
 
 // seg009:0C44

--- a/types.h
+++ b/types.h
@@ -996,12 +996,21 @@ enum seqtbl_sounds {
 
 enum colorids {
 	color_0_black = 0,
+	color_1_blue = 1,
+	color_2_green = 2,
+	color_3_cyan = 3,
 	color_4_red = 4,
-	color_7_grey = 7,
-	color_8_darkgrey = 8,
-	color_12_red = 12,
-	color_14_yellow = 14,
-	color_15_white = 15,
+	color_5_magenta = 5,
+	color_6_brown = 6,
+	color_7_lightgray = 7,
+	color_8_darkgray = 8,
+	color_9_brightblue = 9,
+	color_10_brightgreen = 10,
+	color_11_brightcyan = 11,
+	color_12_brightred = 12,
+	color_13_brightmagenta = 13,
+	color_14_brightyellow = 14,
+	color_15_brightwhite = 15,
 };
 
 #define COUNT(array) (sizeof(array)/sizeof(array[0]))


### PR DESCRIPTION
This adds symbols to the `colorids` enum in `types.h`.
Also renamed some of the existing color names to match the "official names" of the default EGA color palette.

Color names taken from the "Prince of Persia Specifications of File Formats" document, page 9:
http://www.popot.org/documentation.php?doc=FormatSpecifications