### PR TITLE
Set minimum CMake version required to 2.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 2.8)
 project(SDLPoP)
 
 # Use C++11 when using the C++ compiler


### PR DESCRIPTION
As mentioned by @myself600 in issue #31, SDLPoP is buildable with CMake 2.8.