### PR TITLE
Add optimization level (O2) to Makefile, silence uninitialized warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ OS      := $(shell uname)
 ifeq ($(OS),Darwin)
 LIBS := $(shell sdl2-config --libs) -lSDL2_image -lSDL2_mixer
 INCS := -I/opt/local/include
-CFLAGS += $(INCS) -Wall -std=gnu99 -D_GNU_SOURCE=1 -D_THREAD_SAFE -DOSX
+CFLAGS += $(INCS) -Wall -std=gnu99 -D_GNU_SOURCE=1 -D_THREAD_SAFE -DOSX -O2
 else
 LIBS := $(shell pkg-config --libs   sdl2 SDL2_image SDL2_mixer)
 INCS := $(shell pkg-config --cflags sdl2 SDL2_image SDL2_mixer)
-CFLAGS += $(INCS) -Wall -std=gnu99
+CFLAGS += $(INCS) -Wall -std=gnu99 -O2
 endif
 
 all: $(BIN)

--- a/seg009.c
+++ b/seg009.c
@@ -1721,9 +1721,6 @@ void __pascal far play_digi_sound(sound_buffer_type far *buffer) {
 	int sample_rate, sample_size, sample_count;
 	const byte* samples;
 	switch (version) {
-		case 0: // unknown
-			printf("Warning: Can't determine wave version.\n");
-			return;
 		case 1: // 1.0 and 1.1
 			sample_rate = buffer->digi.sample_rate;
 			sample_size = buffer->digi.sample_size;
@@ -1738,6 +1735,9 @@ void __pascal far play_digi_sound(sound_buffer_type far *buffer) {
 			break;
 		case 3: // ambiguous
 			printf("Warning: Ambiguous wave version.\n");
+			return;
+		default: // case 0, unknown
+			printf("Warning: Can't determine wave version.\n");
 			return;
 	}
 #ifndef USE_MIXER	


### PR DESCRIPTION
I've changed `case 0` to `default` to silence warning about possibly uninitialized variable when `O2` level is enabled.