### PR TITLE
Remove CMakeLists.txt in root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ Makefile.win
 
 # CLion
 .idea/
+src/.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,0 @@
-cmake_minimum_required(VERSION 3.1)
-add_subdirectory(source)
-


### PR DESCRIPTION
Additional steps required to open the project correctly in CLion:
- Open the `src/` directory as the project (because this folder contains `CMakeLists.txt`)
- Then, change the project root to the parent folder using Tools > CMake > Change Project Root
- Then, to change the project name (CLion assumes the project is called "src" now), edit the file `src/.idea/.name` and restart CLion
- The IDE project settings are now located in `src/.idea/`. Updated `.gitignore` to ignore these files.