### PR TITLE
Fixes for "standing on thin air" & "glide through wall" fixes

### DIFF
--- a/seg005.c
+++ b/seg005.c
@@ -50,7 +50,6 @@ void __pascal far do_fall() {
 					((curr_tile2 == tiles_12_doortop || curr_tile2 == tiles_7_doortop_with_floor) &&
 					 Char.direction == dir_FF_left)
 			) {
-				Char.fall_x = 0;
 				int delta_x = distance_to_edge_weight();
 				//printf("delta_x = %d\n", delta_x);
 				// When falling into a wall or doortop after turning or running, delta_x is likely to be either 8, 11 or 12
@@ -61,6 +60,8 @@ void __pascal far do_fall() {
 				if (delta_x >= 8) {
 					delta_x = -5 + delta_x - delta_x_reference;
 					Char.x = (byte) char_dx_forward(delta_x);
+
+					Char.fall_x = 0; // not in in_wall(), but we do need to cancel horizontal movement
 				}
 			}
         }

--- a/seg006.c
+++ b/seg006.c
@@ -957,6 +957,21 @@ void __pascal far check_on_floor() {
 				set_wipe(curr_tilepos, 1);
 				set_redraw_full(curr_tilepos, 1);
 			} else {
+
+#ifdef FIX_STAND_ON_THIN_AIR
+				if (options.fix_stand_on_thin_air &&
+					Char.frame >= frame_110_stand_up_from_crouch_1 && Char.frame <= frame_119_stand_up_from_crouch_10)
+				{
+					// We need to prevent the Kid from stepping off a ledge accidentally while standing up.
+					// (This can happen because the "standing up" frames now require a floor.)
+					// --> Cancel the fall, if the tile at dx=2 behind the kid is a valid floor.
+					int col = get_tile_div_mod_m7(dx_weight() + back_delta_x(2));
+					if (tile_is_floor(get_tile(Char.room, col, Char.curr_row))) {
+						return;
+					}
+				}
+#endif
+
 				start_fall();
 			}
 		}

--- a/seqtbl.c
+++ b/seqtbl.c
@@ -1139,13 +1139,6 @@ void apply_seqtbl_patches() {
     if (options.fix_wall_bump_triggers_tile_below)
         SEQTBL_0[bumpfall + 1] = actions_3_in_midair; // instead of actions_5_bumped
 #endif
-#ifdef FIX_STAND_ON_THIN_AIR
-    // Fix tendency to fall off edges with fix applied: kid moves too far forward temporarily
-    if (options.fix_stand_on_thin_air) {
-        SEQTBL_0[standup + 11] -= 1; // dx(1) --> dx(0)
-        SEQTBL_0[standup + 16] += 1; // dx(-4) --> dx(-3)
-    }
-#endif
 }
 
 #ifdef CHECK_SEQTABLE_MATCHES_ORIGINAL


### PR DESCRIPTION
**Improved fix for "standing on thin air" bug**

The changed fix no longer modifies the sequence table (as a workaround to prevent the kid falling off ledges, when standing up from crouching).
The old workaround worked by slightly moving the kid horizontally (so falling off was not possible), but of course this horizontal movement is an unneeded deviation from the original game. The new method prevents the kid from falling in check_on_floor() in seg006.c.

**Fix new falling bug caused by "glide through wall" fix**

Char.fall_x should only be set to zero when facing toward a wall, not away from a wall.
With the "glide through wall" fix active, this could happen, because the game sometimes thinks the kid is "inside" a wall when he is actually just behind it. One reproducible example is the following set-up:

```
__
X __
_ XX
X XX   (underscore = floor, X = wall)
```

In the original game, if you drop down from the upper ledge, you should catch the lower ledge. But if Char.fall_x is set to zero, you miss the ledge.