### PR TITLE
Various gameplay bug fixes

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -143,6 +143,10 @@ fix_drop_through_tapestry = true
 ; (The game considers these tiles floor tiles; so it mistakenly assumes that no x-position adjustment is needed)
 fix_land_against_gate_or_tapestry = true
 
+; Sometimes, the kid may automatically strike immediately after drawing the sword.
+; This especially happens when dropping down from a higher floor and then turning towards the opponent.
+fix_unintended_sword_strike = true
+
 [CustomGameplay]
 ; Starting minutes left. (default = 60)
 start_minutes_left = default

--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -153,6 +153,9 @@ fix_retreat_without_leaving_room = true
 ; The kid can jump through a tapestry with a running jump to the left, if there is a floor above it.
 fix_running_jump_through_tapestry = true
 
+; Guards can be pushed into walls, because the game does not correctly check for walls located behind a guard.
+fix_push_guard_into_wall = true
+
 [CustomGameplay]
 ; Starting minutes left. (default = 60)
 start_minutes_left = default

--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -150,6 +150,9 @@ fix_unintended_sword_strike = true
 ; By repeatedly pressing 'back' in a swordfight, you can retreat out of a room without the room changing. (Trick 35)
 fix_retreat_without_leaving_room = true
 
+; The kid can jump through a tapestry with a running jump to the left, if there is a floor above it.
+fix_running_jump_through_tapestry = true
+
 [CustomGameplay]
 ; Starting minutes left. (default = 60)
 start_minutes_left = default

--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -156,6 +156,9 @@ fix_running_jump_through_tapestry = true
 ; Guards can be pushed into walls, because the game does not correctly check for walls located behind a guard.
 fix_push_guard_into_wall = true
 
+; By doing a running jump into a wall, you can fall behind a closed gate two floors down. (e.g. skip in Level 7)
+fix_jump_through_wall_above_gate = false
+
 [CustomGameplay]
 ; Starting minutes left. (default = 60)
 start_minutes_left = default

--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -147,6 +147,9 @@ fix_land_against_gate_or_tapestry = true
 ; This especially happens when dropping down from a higher floor and then turning towards the opponent.
 fix_unintended_sword_strike = true
 
+; By repeatedly pressing 'back' in a swordfight, you can retreat out of a room without the room changing. (Trick 35)
+fix_retreat_without_leaving_room = true
+
 [CustomGameplay]
 ; Starting minutes left. (default = 60)
 start_minutes_left = default

--- a/config.h
+++ b/config.h
@@ -160,6 +160,9 @@ The authors of this program may be contacted at http://forum.princed.org
 // By repeatedly pressing 'back' in a swordfight, you can retreat out of a room without the room changing. (Trick 35)
 #define FIX_RETREAT_WITHOUT_LEAVING_ROOM
 
+// The kid can jump through a tapestry with a running jump to the left, if there is a floor above it.
+#define FIX_RUNNING_JUMP_THROUGH_TAPESTRY
+
 // Debug features:
 
 // When the program starts, check whether the deobfuscated sequence table (seqtbl.c) is correct.

--- a/config.h
+++ b/config.h
@@ -157,6 +157,9 @@ The authors of this program may be contacted at http://forum.princed.org
 // This especially happens when dropping down from a higher floor and then turning towards the opponent.
 #define FIX_UNINTENDED_SWORD_STRIKE
 
+// By repeatedly pressing 'back' in a swordfight, you can retreat out of a room without the room changing. (Trick 35)
+#define FIX_RETREAT_WITHOUT_LEAVING_ROOM
+
 // Debug features:
 
 // When the program starts, check whether the deobfuscated sequence table (seqtbl.c) is correct.

--- a/config.h
+++ b/config.h
@@ -153,6 +153,10 @@ The authors of this program may be contacted at http://forum.princed.org
 // (The game considers these tiles floor tiles; so it mistakenly assumes that no x-position adjustment is needed)
 #define FIX_LAND_AGAINST_GATE_OR_TAPESTRY
 
+// Sometimes, the kid may automatically strike immediately after drawing the sword.
+// This especially happens when dropping down from a higher floor and then turning towards the opponent.
+#define FIX_UNINTENDED_SWORD_STRIKE
+
 // Debug features:
 
 // When the program starts, check whether the deobfuscated sequence table (seqtbl.c) is correct.

--- a/config.h
+++ b/config.h
@@ -166,6 +166,9 @@ The authors of this program may be contacted at http://forum.princed.org
 // Guards can be pushed into walls, because the game does not correctly check for walls located behind a guard.
 #define FIX_PUSH_GUARD_INTO_WALL
 
+// By doing a running jump into a wall, you can fall behind a closed gate two floors down. (e.g. skip in Level 7)
+#define FIX_JUMP_THROUGH_WALL_ABOVE_GATE
+
 // Debug features:
 
 // When the program starts, check whether the deobfuscated sequence table (seqtbl.c) is correct.

--- a/config.h
+++ b/config.h
@@ -163,6 +163,9 @@ The authors of this program may be contacted at http://forum.princed.org
 // The kid can jump through a tapestry with a running jump to the left, if there is a floor above it.
 #define FIX_RUNNING_JUMP_THROUGH_TAPESTRY
 
+// Guards can be pushed into walls, because the game does not correctly check for walls located behind a guard.
+#define FIX_PUSH_GUARD_INTO_WALL
+
 // Debug features:
 
 // When the program starts, check whether the deobfuscated sequence table (seqtbl.c) is correct.

--- a/options.c
+++ b/options.c
@@ -57,6 +57,7 @@ void use_default_options() {
     options.fix_land_against_gate_or_tapestry = 1;
     options.fix_unintended_sword_strike = 1;
     options.fix_retreat_without_leaving_room = 1;
+    options.fix_running_jump_through_tapestry = 1;
 }
 
 void disable_fixes_and_enhancements() {
@@ -85,6 +86,7 @@ void disable_fixes_and_enhancements() {
     options.fix_land_against_gate_or_tapestry = 0;
     options.fix_unintended_sword_strike = 0;
     options.fix_retreat_without_leaving_room = 0;
+    options.fix_running_jump_through_tapestry= 0;
 }
 
 // .ini file parser adapted from https://gist.github.com/OrangeTide/947070
@@ -276,6 +278,7 @@ static int global_ini_callback(const char *section, const char *name, const char
         process_boolean("fix_land_against_gate_or_tapestry", &options.fix_land_against_gate_or_tapestry);
         process_boolean("fix_unintended_sword_strike", &options.fix_unintended_sword_strike);
         process_boolean("fix_retreat_without_leaving_room", &options.fix_retreat_without_leaving_room);
+        process_boolean("fix_running_jump_through_tapestry", &options.fix_running_jump_through_tapestry);
     }
 
     if (check_ini_section("CustomGameplay")) {

--- a/options.c
+++ b/options.c
@@ -56,6 +56,7 @@ void use_default_options() {
     options.fix_drop_through_tapestry = 1;
     options.fix_land_against_gate_or_tapestry = 1;
     options.fix_unintended_sword_strike = 1;
+    options.fix_retreat_without_leaving_room = 1;
 }
 
 void disable_fixes_and_enhancements() {
@@ -83,6 +84,7 @@ void disable_fixes_and_enhancements() {
     options.fix_drop_through_tapestry = 0;
     options.fix_land_against_gate_or_tapestry = 0;
     options.fix_unintended_sword_strike = 0;
+    options.fix_retreat_without_leaving_room = 0;
 }
 
 // .ini file parser adapted from https://gist.github.com/OrangeTide/947070
@@ -273,6 +275,7 @@ static int global_ini_callback(const char *section, const char *name, const char
         process_boolean("fix_drop_through_tapestry", &options.fix_drop_through_tapestry);
         process_boolean("fix_land_against_gate_or_tapestry", &options.fix_land_against_gate_or_tapestry);
         process_boolean("fix_unintended_sword_strike", &options.fix_unintended_sword_strike);
+        process_boolean("fix_retreat_without_leaving_room", &options.fix_retreat_without_leaving_room);
     }
 
     if (check_ini_section("CustomGameplay")) {

--- a/options.c
+++ b/options.c
@@ -59,6 +59,7 @@ void use_default_options() {
     options.fix_retreat_without_leaving_room = 1;
     options.fix_running_jump_through_tapestry = 1;
     options.fix_push_guard_into_wall = 1;
+    options.fix_jump_through_wall_above_gate = 1;
 }
 
 void disable_fixes_and_enhancements() {
@@ -89,6 +90,7 @@ void disable_fixes_and_enhancements() {
     options.fix_retreat_without_leaving_room = 0;
     options.fix_running_jump_through_tapestry= 0;
     options.fix_push_guard_into_wall = 0;
+    options.fix_jump_through_wall_above_gate = 0;
 }
 
 // .ini file parser adapted from https://gist.github.com/OrangeTide/947070
@@ -282,6 +284,7 @@ static int global_ini_callback(const char *section, const char *name, const char
         process_boolean("fix_retreat_without_leaving_room", &options.fix_retreat_without_leaving_room);
         process_boolean("fix_running_jump_through_tapestry", &options.fix_running_jump_through_tapestry);
         process_boolean("fix_push_guard_into_wall", &options.fix_push_guard_into_wall);
+        process_boolean("fix_jump_through_wall_above_gate", &options.fix_jump_through_wall_above_gate);
     }
 
     if (check_ini_section("CustomGameplay")) {

--- a/options.c
+++ b/options.c
@@ -58,6 +58,7 @@ void use_default_options() {
     options.fix_unintended_sword_strike = 1;
     options.fix_retreat_without_leaving_room = 1;
     options.fix_running_jump_through_tapestry = 1;
+    options.fix_push_guard_into_wall = 1;
 }
 
 void disable_fixes_and_enhancements() {
@@ -87,6 +88,7 @@ void disable_fixes_and_enhancements() {
     options.fix_unintended_sword_strike = 0;
     options.fix_retreat_without_leaving_room = 0;
     options.fix_running_jump_through_tapestry= 0;
+    options.fix_push_guard_into_wall = 0;
 }
 
 // .ini file parser adapted from https://gist.github.com/OrangeTide/947070
@@ -279,6 +281,7 @@ static int global_ini_callback(const char *section, const char *name, const char
         process_boolean("fix_unintended_sword_strike", &options.fix_unintended_sword_strike);
         process_boolean("fix_retreat_without_leaving_room", &options.fix_retreat_without_leaving_room);
         process_boolean("fix_running_jump_through_tapestry", &options.fix_running_jump_through_tapestry);
+        process_boolean("fix_push_guard_into_wall", &options.fix_push_guard_into_wall);
     }
 
     if (check_ini_section("CustomGameplay")) {

--- a/options.c
+++ b/options.c
@@ -55,6 +55,7 @@ void use_default_options() {
     options.fix_glide_through_wall = 1;
     options.fix_drop_through_tapestry = 1;
     options.fix_land_against_gate_or_tapestry = 1;
+    options.fix_unintended_sword_strike = 1;
 }
 
 void disable_fixes_and_enhancements() {
@@ -81,6 +82,7 @@ void disable_fixes_and_enhancements() {
     options.fix_glide_through_wall = 0;
     options.fix_drop_through_tapestry = 0;
     options.fix_land_against_gate_or_tapestry = 0;
+    options.fix_unintended_sword_strike = 0;
 }
 
 // .ini file parser adapted from https://gist.github.com/OrangeTide/947070
@@ -270,6 +272,7 @@ static int global_ini_callback(const char *section, const char *name, const char
         process_boolean("fix_glide_through_wall", &options.fix_glide_through_wall);
         process_boolean("fix_drop_through_tapestry", &options.fix_drop_through_tapestry);
         process_boolean("fix_land_against_gate_or_tapestry", &options.fix_land_against_gate_or_tapestry);
+        process_boolean("fix_unintended_sword_strike", &options.fix_unintended_sword_strike);
     }
 
     if (check_ini_section("CustomGameplay")) {

--- a/seg002.c
+++ b/seg002.c
@@ -352,7 +352,21 @@ short __pascal far leave_room() {
 		// frames 110..119: standing up from crouch
 		(frame >= frame_110_stand_up_from_crouch_1 && frame < 120) ||
 		// frames 150..162: with sword
-		(frame >= frame_150_parry && frame < 163) ||
+		(frame >= frame_150_parry && frame < 163
+
+#ifdef FIX_RETREAT_WITHOUT_LEAVING_ROOM
+           // By repeatedly pressing 'back' in a swordfight, you can retreat out of a room without the room changing. (Trick 35)
+
+           // The game waits for a 'legal frame' (e.g. frame_170_stand_with_sword) until leaving is possible;
+           // However, this frame is never reached if you press 'back' in the correct pattern!
+
+           // Solution: also allow the room to be changed on frame_157_walk_with_sword
+           // Note that this means that the delay for leaving rooms in a swordfight becomes noticably shorter.
+
+		   && (frame != frame_157_walk_with_sword || !options.fix_retreat_without_leaving_room)
+#endif
+
+		) ||
 		// frames 166..168: with sword
 		(frame >= frame_166_stand_inactive && frame < 169) ||
 		action == actions_7_turn // turn

--- a/seg004.c
+++ b/seg004.c
@@ -486,13 +486,18 @@ void __pascal far check_gate_push() {
 
 // seg004:08C3
 void __pascal far check_guard_bumped() {
-	short var_2;
 	if (
 		Char.action == actions_1_run_jump &&
 		Char.alive < 0 &&
 		Char.sword >= sword_2_drawn
 	) {
 		if (
+
+			#ifdef FIX_PUSH_GUARD_INTO_WALL
+            // Should also check for a wall BEHIND the guard, instead of only the current tile
+			(options.fix_push_guard_into_wall && get_tile_behind_char() == tiles_20_wall) ||
+			#endif
+
 			get_tile_at_char() == tiles_20_wall ||
 			curr_tile2 == tiles_7_doortop_with_floor ||
 			(curr_tile2 == tiles_4_gate && can_bump_into_gate()) ||
@@ -504,9 +509,10 @@ void __pascal far check_guard_bumped() {
 			load_frame_to_obj();
 			set_char_collision();
 			if (is_obstacle()) {
-				var_2 = dist_from_wall_behind(curr_tile2);
-				if (var_2 < 0 && var_2 > -13) {
-					Char.x = char_dx_forward(-var_2);
+				short delta_x;
+				delta_x = dist_from_wall_behind(curr_tile2);
+				if (delta_x < 0 && delta_x > -13) {
+					Char.x = char_dx_forward(-delta_x);
 					seqtbl_offset_char(seq_65_bump_forward_with_sword); // pushed to wall with sword (Guard)
 					play_seq();
 					load_fram_det_col();

--- a/seg005.c
+++ b/seg005.c
@@ -784,6 +784,11 @@ void __pascal far draw_sword() {
 	word seq_id;
 	seq_id = seq_55_draw_sword; // draw sword
 	control_forward = control_shift2 = release_arrows();
+#ifdef FIX_UNINTENDED_SWORD_STRIKE
+	if (options.fix_unintended_sword_strike) {
+		ctrl1_shift2 = 1; // prevent restoring control_shift2 to -1 in rest_ctrl_1()
+	}
+#endif
 	if (Char.charid == charid_0_kid) {
 		play_sound(sound_19_draw_sword); // taking out the sword
 		offguard = 0;

--- a/seg005.c
+++ b/seg005.c
@@ -68,6 +68,20 @@ void __pascal far do_fall() {
         #endif
 
 	} else {
+
+		#ifdef FIX_JUMP_THROUGH_WALL_ABOVE_GATE
+		if (options.fix_jump_through_wall_above_gate) {
+			// At this point, Char.curr_col has not yet been updated since check_bumped()
+			// Basically, Char.curr_col is still set to the column of the wall itself (even though the kid
+			// may have 'bumped' against the wall, with Char.x being offset)
+
+			// To prevent in_wall() from being called we need to update Char.curr_col here.
+			// (in_wall() only makes things worse, because it tries to 'eject' the kid from the wall the wrong way.
+			// For this reason, the kid can end up behind a closed gate below, like is possible in Level 7)
+			determine_col();
+		}
+        #endif
+
 		if (get_tile_at_char() == tiles_20_wall) {
 			in_wall();
 		}

--- a/seg006.c
+++ b/seg006.c
@@ -1037,7 +1037,16 @@ void __pascal far start_fall() {
 		in_wall();
 		return;
 	}
-	if (get_tile_infrontof_char() == tiles_20_wall) {
+	int tile = get_tile_infrontof_char();
+	if (tile == tiles_20_wall
+
+		#ifdef FIX_RUNNING_JUMP_THROUGH_TAPESTRY
+		    // Also treat tapestries (when approached to the left) like a wall here.
+		|| (options.fix_running_jump_through_tapestry && Char.direction == dir_FF_left &&
+			(tile == tiles_12_doortop || tile == tiles_7_doortop_with_floor))
+        #endif
+
+			) {
 		if (fall_frame != 44 || distance_to_edge_weight() >= 6) {
 			Char.x = char_dx_forward(-1);
 		} else {

--- a/types.h
+++ b/types.h
@@ -1071,6 +1071,7 @@ typedef union options_type {
 		byte fix_glide_through_wall;
 		byte fix_drop_through_tapestry;
 		byte fix_land_against_gate_or_tapestry;
+		byte fix_unintended_sword_strike;
 	};
 } options_type;
 

--- a/types.h
+++ b/types.h
@@ -1075,6 +1075,7 @@ typedef union options_type {
 		byte fix_retreat_without_leaving_room;
 		byte fix_running_jump_through_tapestry;
 		byte fix_push_guard_into_wall;
+		byte fix_jump_through_wall_above_gate;
 	};
 } options_type;
 

--- a/types.h
+++ b/types.h
@@ -1073,6 +1073,7 @@ typedef union options_type {
 		byte fix_land_against_gate_or_tapestry;
 		byte fix_unintended_sword_strike;
 		byte fix_retreat_without_leaving_room;
+		byte fix_running_jump_through_tapestry;
 	};
 } options_type;
 

--- a/types.h
+++ b/types.h
@@ -1074,6 +1074,7 @@ typedef union options_type {
 		byte fix_unintended_sword_strike;
 		byte fix_retreat_without_leaving_room;
 		byte fix_running_jump_through_tapestry;
+		byte fix_push_guard_into_wall;
 	};
 } options_type;
 

--- a/types.h
+++ b/types.h
@@ -1072,6 +1072,7 @@ typedef union options_type {
 		byte fix_drop_through_tapestry;
 		byte fix_land_against_gate_or_tapestry;
 		byte fix_unintended_sword_strike;
+		byte fix_retreat_without_leaving_room;
 	};
 } options_type;
 


### PR DESCRIPTION
**Fix unintended sword strike immediately after drawing sword**
Sometimes, the kid may automatically strike immediately after drawing the sword.
This especially happens when dropping down from a higher floor and then turning towards the opponent.

I think this happens because `ctrl1_shift2` may still be -1 in `draw_sword()`, after which `control_shift2` is set to -1 in `rest_ctrl1()`.

**Fix retreating out of a room without the room actually changing**
By repeatedly pressing 'back' in a swordfight, you can retreat out of a room without the room changing. (Trick 35)

The game waits for a 'legal frame' (e.g. `frame_170_stand_with_sword`) until leaving is possible;
However, this frame is never reached if you press 'back' in the correct pattern!

Proposed solution: also allow the room to be changed on `frame_157_walk_with_sword`
Note that this means that the delay for leaving rooms in a swordfight becomes noticably shorter.

**Fix running jump through tapestry**
The kid can jump through a tapestry with a running jump to the left, if there is a floor above it (when you just miss that floor, the kid jumps through the tapestry instead of falling down in front of it)

The proposed solution is to treat tapestries (when approached to the left) as if they are a wall in `start_fall()`.

**Fix guards being pushed into walls**
Guards can be pushed into walls, because the game does not correctly check for walls located behind a guard.

**Fix jumping through a wall above a closed gate**
By doing a running jump into a wall, you can fall behind a closed gate two floors down. (e.g. skip in Level 7)

This happens because `in_wall()` mistakenly gets called (which in turn happens because `Char.curr_col` is not immediately updated after jumping into a wall and getting bumped, even though `Char.x` has been changed) and `in_wall()` tries to 'eject' the kid from the wall, but in the wrong direction.
The proposed fix is to update `Char.curr_col` by calling `determine_col()` in `do_fall()`.