### PR TITLE
Debug timer: display in top left corner, toggle with T

### DIFF
--- a/config.h
+++ b/config.h
@@ -174,9 +174,9 @@ The authors of this program may be contacted at http://forum.princed.org
 // When the program starts, check whether the deobfuscated sequence table (seqtbl.c) is correct.
 //#define CHECK_SEQTABLE_MATCHES_ORIGINAL
 
-// Enable debug cheats
+// Enable debug cheats (with command-line argument "debug")
 // "[" and "]" : nudge x position by one pixel
 // "T" : display remaining time in minutes, seconds and ticks
-//#define USE_DEBUG_CHEATS
+#define USE_DEBUG_CHEATS
 
 #endif

--- a/data.h
+++ b/data.h
@@ -197,7 +197,8 @@ extern word is_blind_mode;
 
 // data:0F86
 extern const rect_type rect_top INIT(= {0, 0, 192, 320});
-
+// data:0F96
+extern const rect_type rect_bottom_text INIT(= {193, 70, 202, 250});
 
 // data:4CB2
 extern word leveldoor_right;
@@ -593,6 +594,12 @@ extern word max_hitp_allowed INIT(= 10);
 extern word saving_allowed_first_level INIT(= 3);
 extern word saving_allowed_last_level INIT(= 13);
 extern byte allow_triggering_any_tile INIT(= 0);
+
+#ifdef USE_DEBUG_CHEATS
+extern byte debug_cheats_enabled INIT(= 0);
+extern const rect_type timer_rect INIT(= {1, 2, 8, 55});
+extern byte is_timer_displayed INIT(= 0);
+#endif
 
 #undef INIT
 #undef extern

--- a/seg000.c
+++ b/seg000.c
@@ -644,10 +644,10 @@ int __pascal far process_key() {
 			break;
 			#ifdef USE_DEBUG_CHEATS
 			case SDL_SCANCODE_T:
-				printf("Remaining minutes: %d\tticks:%d\n", rem_min, rem_tick);
-				snprintf(sprintf_temp, sizeof(sprintf_temp), "M:%d S:%d T:%d", rem_min, rem_tick / 12, rem_tick);
-				answer_text = sprintf_temp;
-				need_show_text = 1;
+				is_timer_displayed = 1 - is_timer_displayed; // toggle
+				if (!is_timer_displayed) {
+					need_full_redraw = 1;
+				}
 			break;
 			#endif
 		}
@@ -1327,7 +1327,7 @@ void __pascal far read_keyb_control() {
 	control_shift = -(key_states[SDL_SCANCODE_LSHIFT] || key_states[SDL_SCANCODE_RSHIFT]);
 
 	#ifdef USE_DEBUG_CHEATS
-	if (cheats_enabled) {
+	if (cheats_enabled && debug_cheats_enabled) {
 		if (key_states[SDL_SCANCODE_RIGHTBRACKET]) ++Char.x;
 		else if (key_states[SDL_SCANCODE_LEFTBRACKET]) --Char.x;
 	}

--- a/seg000.c
+++ b/seg000.c
@@ -59,8 +59,9 @@ void far pop_main() {
 	show_loading();
 	set_joy_mode();
 	cheats_enabled = check_param("megahit") != NULL;
-#ifdef __DEBUG__
-	cheats_enabled = 1; // debug
+#ifdef USE_DEBUG_CHEATS
+	debug_cheats_enabled = check_param("debug") != NULL;
+	if (debug_cheats_enabled) cheats_enabled = 1; // param 'megahit' not necessary if 'debug' is used
 #endif
 	draw_mode = check_param("draw") != NULL && cheats_enabled;
 	demo_mode = check_param("demo") != NULL;

--- a/seg003.c
+++ b/seg003.c
@@ -345,6 +345,18 @@ int __pascal far play_level_2() {
 				}
 				screen_updates_suspended = 0;
 				remove_flash_if_hurt();
+
+				#ifdef USE_DEBUG_CHEATS
+                if (debug_cheats_enabled && is_timer_displayed) {
+					char timer_text[16];
+					snprintf(timer_text, 16, "%02d:%02d:%02d", rem_min - 1, rem_tick / 12, rem_tick % 12);
+					screen_updates_suspended = 1;
+					draw_rect(&timer_rect, color_0_black);
+					show_text(&timer_rect, -1, -1, timer_text);
+					screen_updates_suspended = 0;
+				}
+                #endif
+
 				request_screen_update(); // request screen update manually
 				do_simple_wait(1);
 			} else {

--- a/seg008.c
+++ b/seg008.c
@@ -1760,8 +1760,6 @@ void __pascal far free_peels() {
 	}
 }
 
-// data:0F96
-const rect_type rect_bottom_text = {193, 70, 202, 250};
 
 // seg008:2644
 void __pascal far display_text_bottom(const char near *text) {


### PR DESCRIPTION
This improves the debug timer, so that it stays active in the top left corner and can be toggled on and off with T.

Edit:
I added a way to enable debug cheats using a proposed command line argument 'debug'.