### PR TITLE
Allow choosing a levelset from the command line (mod "Mod Name")

### DIFF
--- a/doc/Readme.txt
+++ b/doc/Readme.txt
@@ -79,6 +79,7 @@ A:
 * demo -- Run in demo mode: only the first two levels will be playable, and quotes from magazine reviews will be displayed.
 * record -- Start recording immediately. (See the Replays section.)
 * replay or a *.P1R filename -- Start replaying immediately. (See the Replays section.)
+* mod "Mod Name" -- Run with custom data files from the folder "mods/Mod Name/"
 
 Q: What keys can I use?
 A:
@@ -157,9 +158,11 @@ A:
 Since version 1.02, the game supports LEVELS.DAT, and since version 1.03, the game can use all .DAT files.
 You can either copy the modified .DAT files to the folder of the game, or the game to the mod's folder.
 
-Since version 1.17, the game can also load from mod folders that have been placed in the mods/ directory.
-To choose which mod to play, open SDLPoP.ini and change the 'levelset' option to the name of the mod folder.
+Since version 1.17, the game can also load from mod folders that have been placed in the "mods/" directory.
 If you use this method, only the files different from the original V1.0 data are required in the mod's folder.
+To choose which mod to play, do one of the following:
+* Open SDLPoP.ini and change the 'levelset' option to the name of the mod folder.
+* Use the command line option "mod", like so: prince.exe mod "Mod Name"
 
 Another way is to start the game while the current directory is the mod's directory.
 You can do this from the command line, or with batch files / shell scripts.

--- a/options.c
+++ b/options.c
@@ -331,6 +331,15 @@ void load_options() {
     use_default_options();
     ini_load("SDLPoP.ini", global_ini_callback); // global configuration
 
+    // The 'mod=' command line argument can override the levelset choice in SDLPoP.ini
+    // usage: prince mod="My Mod Name"
+    const char* mod_param = check_param("mod=");
+    if (mod_param != NULL) {
+        use_custom_levelset = true;
+        memset(levelset_name, 0, sizeof(levelset_name));
+        strncpy(levelset_name, &mod_param[4], sizeof(levelset_name));
+    }
+
     // load mod-specific INI configuration
     if (use_custom_levelset) {
         char filename[256];

--- a/options.c
+++ b/options.c
@@ -331,13 +331,13 @@ void load_options() {
     use_default_options();
     ini_load("SDLPoP.ini", global_ini_callback); // global configuration
 
-    // The 'mod=' command line argument can override the levelset choice in SDLPoP.ini
-    // usage: prince mod="My Mod Name"
-    const char* mod_param = check_param("mod=");
+    // The 'mod' command line argument can override the levelset choice in SDLPoP.ini
+    // usage: prince mod "Mod Name"
+    const char* mod_param = check_param("mod");
     if (mod_param != NULL) {
         use_custom_levelset = true;
         memset(levelset_name, 0, sizeof(levelset_name));
-        strncpy(levelset_name, &mod_param[4], sizeof(levelset_name));
+        strncpy(levelset_name, mod_param, sizeof(levelset_name));
     }
 
     // load mod-specific INI configuration

--- a/seg009.c
+++ b/seg009.c
@@ -101,11 +101,35 @@ const char* __pascal far check_param(const char *param) {
 	// stub
 	short arg_index;
 	for (arg_index = 1; arg_index < g_argc; ++arg_index) {
-		if (/*strnicmp*/strncasecmp(g_argv[arg_index], param, strlen(param)) == 0) {
+
+		char* curr_arg = g_argv[arg_index];
+
+		// List of params that expect a specifier ('sub-') arg directly after it (e.g. the mod's name, after "mod" arg)
+		// Such sub-args may conflict with the normal params (so, we should 'skip over' them)
+		static const char params_with_one_subparam[][8] = { "mod", /*...*/ };
+
+		bool curr_arg_has_one_subparam = false;
+		int i;
+		for (i = 0; i < COUNT(params_with_one_subparam); ++i) {
+			if (strncasecmp(curr_arg, params_with_one_subparam[i], strlen(params_with_one_subparam[i])) == 0) {
+				curr_arg_has_one_subparam = true;
+				break;
+			}
+		}
+
+		if (curr_arg_has_one_subparam) {
+			// Found an arg that has one sub-param, so we want to:
+			// 1: skip over the next arg                (if we are NOT checking for this specific param)
+			// 2: return a pointer below to the SUB-arg (if we ARE checking for this specific param)
+			++arg_index;
+			if (!(arg_index < g_argc)) return NULL; // not enough arguments
+		}
+
+		if (/*strnicmp*/strncasecmp(curr_arg, param, strlen(param)) == 0) {
 			return g_argv[arg_index];
 		}
 	}
-	return 0;
+	return NULL;
 }
 
 // seg009:0EDF

--- a/seg009.c
+++ b/seg009.c
@@ -104,6 +104,13 @@ const char* __pascal far check_param(const char *param) {
 
 		char* curr_arg = g_argv[arg_index];
 
+		// Filenames (e.g. replays) should never be a valid 'normal' param so we should skip these to prevent conflicts.
+		// We can lazily distinguish filenames from non-filenames by checking whether they have a dot in them.
+		// (Assumption: all relevant files, e.g. replay files, have some file extension anyway)
+		if (strchr(curr_arg, '.') != NULL) {
+			continue;
+		}
+
 		// List of params that expect a specifier ('sub-') arg directly after it (e.g. the mod's name, after "mod" arg)
 		// Such sub-args may conflict with the normal params (so, we should 'skip over' them)
 		static const char params_with_one_subparam[][8] = { "mod", /*...*/ };


### PR DESCRIPTION
This adds a way to launch a specific mod (levelset) in the `mods/` folder directly from the command line.
Proposed usage is `prince mod="Mod Name"`
Using the command line argument disregards the setting of the 'levelset' option in SDLPoP.ini.

EDIT:
There seems to be a problem with passing an argument like so `mod="Mod Name"`
Apparently, the arguments get split into `mod="Mod` and `Name"` separately.
It does however work as intended like so: `prince "mod=Mod Name"` but that is a big ugly...
Perhaps we should alternatively try something like this, without an equals sign: `prince mod "Mod Name"`
Then there is a potential problem, however, because mod names may conflict with other command-line options which get parsed in `check_param()`. Maybe adding exception cases to `check_param()` would solve that (i.e. we need to make sure that the argument passed directly after `mod` gets ignored as a normal argument).

EDIT2:
In the second commit I changed the usage syntax to `prince mod "Mod Name"` and changed `check_param()` so that mod names do not conflict with the normal command line parameters.