### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+# Code style
+[*]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
This should hopefully help to make GitHub display the tab size properly (tab size 4 instead of 8). Also, some code editors will apparently adopt the correct indentation method automatically.
See https://github.com/RReverser/github-editorconfig#readme