### PR TITLE
Add new CusPop options

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -179,6 +179,9 @@ fix_jump_through_wall_above_gate = false
 ; Last level where you can save the game. (default = 13)
 ;saving_allowed_last_level = 13
 
+; Start the game with the screen flipped upside down, similar to Shift+I (default = false)
+;start_upside_down = false
+
 ; Enable triggering any tile. (default = false)
 ; For example, a button could make loose floors fall, or start a stuck chomper.
 ;allow_triggering_any_tile = false

--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -185,6 +185,9 @@ fix_jump_through_wall_above_gate = false
 ; Start in blind mode, similar to Shift+B (default = false)
 ;start_in_blind_mode = true
 
+; The potions level will appear before this level. Set to -1 to disable. (default = 2)
+;copyprot_level = 2
+
 ; Enable triggering any tile. (default = false)
 ; For example, a button could make loose floors fall, or start a stuck chomper.
 ;allow_triggering_any_tile = false

--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -182,6 +182,9 @@ fix_jump_through_wall_above_gate = false
 ; Start the game with the screen flipped upside down, similar to Shift+I (default = false)
 ;start_upside_down = false
 
+; Start in blind mode, similar to Shift+B (default = false)
+;start_in_blind_mode = true
+
 ; Enable triggering any tile. (default = false)
 ; For example, a button could make loose floors fall, or start a stuck chomper.
 ;allow_triggering_any_tile = false

--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -161,27 +161,27 @@ fix_jump_through_wall_above_gate = false
 
 [CustomGameplay]
 ; Starting minutes left. (default = 60)
-start_minutes_left = default
+;start_minutes_left = 60
 
 ; Starting number of ticks left in the first minute. (default = 719)
 ; 1 tick = 1/12 second, so by default there are 59.92 seconds left in the first minute.
-start_ticks_left = default
+;start_ticks_left = 719
 
 ; Starting hitpoints. (default = 3)
-start_hitp = default
+;start_hitp = 3
 
 ; Maximum number of hitpoints you can get. (default = 10)
-max_hitp_allowed = default
+;max_hitp_allowed = 10
 
 ; First level where you can save the game. (default = 3)
-saving_allowed_first_level = default
+;saving_allowed_first_level = 3
 
 ; Last level where you can save the game. (default = 13)
-saving_allowed_last_level = default
+;saving_allowed_last_level = 13
 
 ; Enable triggering any tile. (default = false)
 ; For example, a button could make loose floors fall, or start a stuck chomper.
-allow_triggering_any_tile = false
+;allow_triggering_any_tile = false
 
 ; The following customization options can be used in all level sections:
 ; level_type = 0: dungeon, 1: palace

--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -203,6 +203,10 @@ fix_jump_through_wall_above_gate = false
 ; For example, a button could make loose floors fall, or start a stuck chomper.
 ;allow_triggering_any_tile = false
 
+; Enable the dungeon Wall Drawing Algorithm (WDA) in the palace environment.
+; N.B. Use with a modified VPALACE.DAT that provides dungeon-like wall graphics!
+;enable_wda_in_palace = false
+
 ; The following customization options can be used in all level sections:
 ; level_type = 0: dungeon, 1: palace
 ; level_color = 0: colors from VDUNGEON.DAT/VPALACE.DAT, >0: colors from PRINCE.DAT (You need a PRINCE.DAT from 1.3 or 1.4 for this.)

--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -188,6 +188,17 @@ fix_jump_through_wall_above_gate = false
 ; The potions level will appear before this level. Set to -1 to disable. (default = 2)
 ;copyprot_level = 2
 
+; Set up edges of the level.
+; Tile drawn at the top of the room if there is no room that way. (default = floor)
+; E.g. 0: empty, 1: floor, 20: wall (etc.)
+;drawn_tile_top_level_edge = floor
+
+; Tile drawn at the left of the room if there is no room that way. (default = wall)
+;drawn_tile_left_level_edge = wall
+
+; Tile behavior at the top or left of the room if there is no room that way (default = wall)
+;level_edge_hit_tile = wall
+
 ; Enable triggering any tile. (default = false)
 ; For example, a button could make loose floors fall, or start a stuck chomper.
 ;allow_triggering_any_tile = false

--- a/data.h
+++ b/data.h
@@ -594,6 +594,9 @@ extern word saving_allowed_first_level INIT(= 3);
 extern word saving_allowed_last_level INIT(= 13);
 extern byte start_upside_down INIT(= 0);
 extern byte start_in_blind_mode INIT(= 0);
+extern byte drawn_tile_top_level_edge INIT(= tiles_1_floor);
+extern byte drawn_tile_left_level_edge INIT(= tiles_20_wall);
+extern byte level_edge_hit_tile INIT(= tiles_20_wall);
 extern byte allow_triggering_any_tile INIT(= 0);
 
 #undef INIT

--- a/data.h
+++ b/data.h
@@ -598,6 +598,7 @@ extern byte drawn_tile_top_level_edge INIT(= tiles_1_floor);
 extern byte drawn_tile_left_level_edge INIT(= tiles_20_wall);
 extern byte level_edge_hit_tile INIT(= tiles_20_wall);
 extern byte allow_triggering_any_tile INIT(= 0);
+extern byte enable_wda_in_palace INIT(= 0);
 
 #undef INIT
 #undef extern

--- a/data.h
+++ b/data.h
@@ -593,6 +593,7 @@ extern word max_hitp_allowed INIT(= 10);
 extern word saving_allowed_first_level INIT(= 3);
 extern word saving_allowed_last_level INIT(= 13);
 extern byte start_upside_down INIT(= 0);
+extern byte start_in_blind_mode INIT(= 0);
 extern byte allow_triggering_any_tile INIT(= 0);
 
 #undef INIT

--- a/data.h
+++ b/data.h
@@ -592,6 +592,7 @@ extern word start_hitp INIT(= 3);
 extern word max_hitp_allowed INIT(= 10);
 extern word saving_allowed_first_level INIT(= 3);
 extern word saving_allowed_last_level INIT(= 13);
+extern byte start_upside_down INIT(= 0);
 extern byte allow_triggering_any_tile INIT(= 0);
 
 #undef INIT

--- a/options.c
+++ b/options.c
@@ -135,7 +135,7 @@ int ini_load(const char *filename,
     return 0;
 }
 
-#define MAX_NAME_LENGTH 16
+#define MAX_NAME_LENGTH 20
 typedef struct ini_value_list_type {
     const char (* names)[][MAX_NAME_LENGTH];
     word num_names;
@@ -143,9 +143,19 @@ typedef struct ini_value_list_type {
 
 const char level_type_names[][MAX_NAME_LENGTH] = {"dungeon", "palace"};
 const char guard_type_names[][MAX_NAME_LENGTH] = {"guard", "fat", "skel", "vizier", "shadow"};
+const char tile_type_names[][MAX_NAME_LENGTH] = {
+				"empty", "floor", "spike", "pillar", "gate",                                        // 0..4
+				"stuck", "closer", "doortop_with_floor", "bigpillar_bottom", "bigpillar_top",       // 5..9
+				"potion", "loose", "doortop", "mirror", "debris",                                   // 10..14
+				"opener", "level_door_left", "level_door_right", "chomper", "torch",                // 15..19
+				"wall", "skeleton", "sword", "balcony_left", "balcony_right",                       // 20..24
+				"lattice_pillar", "lattice_down", "lattice_small", "lattice_left", "lattice_right", // 25..29
+				"torch_with_debris", // 30
+};
 
 ini_value_list_type level_type_names_list = {&level_type_names, COUNT(level_type_names)};
 ini_value_list_type guard_type_names_list = {&guard_type_names, COUNT(guard_type_names)};
+ini_value_list_type tile_type_names_list = {&tile_type_names, COUNT(tile_type_names)};
 
 #define INI_NO_VALID_NAME -9999
 
@@ -297,6 +307,9 @@ static int global_ini_callback(const char *section, const char *name, const char
         process_boolean("start_upside_down", &start_upside_down);
         process_boolean("start_in_blind_mode", &start_in_blind_mode);
         process_word("copyprot_level", &copyprot_level, NULL);
+        process_byte("drawn_tile_top_level_edge", &drawn_tile_top_level_edge, &tile_type_names_list);
+        process_byte("drawn_tile_left_level_edge", &drawn_tile_left_level_edge, &tile_type_names_list);
+        process_byte("level_edge_hit_tile", &level_edge_hit_tile, &tile_type_names_list);
         process_boolean("allow_triggering_any_tile", &allow_triggering_any_tile);
     }
 

--- a/options.c
+++ b/options.c
@@ -296,6 +296,7 @@ static int global_ini_callback(const char *section, const char *name, const char
         process_word("saving_allowed_last_level", &saving_allowed_last_level, NULL);
         process_boolean("start_upside_down", &start_upside_down);
         process_boolean("start_in_blind_mode", &start_in_blind_mode);
+        process_word("copyprot_level", &copyprot_level, NULL);
         process_boolean("allow_triggering_any_tile", &allow_triggering_any_tile);
     }
 

--- a/options.c
+++ b/options.c
@@ -311,6 +311,8 @@ static int global_ini_callback(const char *section, const char *name, const char
         process_byte("drawn_tile_left_level_edge", &drawn_tile_left_level_edge, &tile_type_names_list);
         process_byte("level_edge_hit_tile", &level_edge_hit_tile, &tile_type_names_list);
         process_boolean("allow_triggering_any_tile", &allow_triggering_any_tile);
+        // TODO: Maybe allow automatically choosing the correct WDA, depending on the loaded VDUNGEON.DAT?
+		process_boolean("enable_wda_in_palace", &enable_wda_in_palace);
     }
 
     // [Level 1], etc.

--- a/options.c
+++ b/options.c
@@ -294,6 +294,7 @@ static int global_ini_callback(const char *section, const char *name, const char
         process_word("max_hitp_allowed", &max_hitp_allowed, NULL);
         process_word("saving_allowed_first_level", &saving_allowed_first_level, NULL);
         process_word("saving_allowed_last_level", &saving_allowed_last_level, NULL);
+        process_boolean("start_upside_down", &start_upside_down);
         process_boolean("allow_triggering_any_tile", &allow_triggering_any_tile);
     }
 

--- a/options.c
+++ b/options.c
@@ -295,6 +295,7 @@ static int global_ini_callback(const char *section, const char *name, const char
         process_word("saving_allowed_first_level", &saving_allowed_first_level, NULL);
         process_word("saving_allowed_last_level", &saving_allowed_last_level, NULL);
         process_boolean("start_upside_down", &start_upside_down);
+        process_boolean("start_in_blind_mode", &start_in_blind_mode);
         process_boolean("allow_triggering_any_tile", &allow_triggering_any_tile);
     }
 
@@ -340,6 +341,10 @@ void load_options() {
     }
 
     if (!options.use_fixes_and_enhancements) disable_fixes_and_enhancements();
+
+    // CusPop option
+    is_blind_mode = start_in_blind_mode;
+    // Bug: with start_in_blind_mode enabled, moving objects are not displayed until blind mode is toggled off+on??
 }
 
 void show_use_fixes_and_enhancements_prompt() {

--- a/seg003.c
+++ b/seg003.c
@@ -35,7 +35,7 @@ void __pascal far init_game(int level) {
 	text_time_total = 0;
 	is_show_time = 0;
 	checkpoint = 0;
-	upside_down = 0;
+	upside_down = 0; // N.B. upside_down is also reset in set_start_pos()
 	resurrect_time = 0;
 	if (!dont_reset_time) {
 		rem_min = start_minutes_left; 	// 60
@@ -195,7 +195,7 @@ void __pascal far set_start_pos() {
 	Char.charid = charid_0_kid;
 	is_screaming = 0;
 	knock = 0;
-	upside_down = 0;
+	upside_down = start_upside_down; // 0
 	is_feather_fall = 0;
 	Char.fall_y = 0;
 	Char.fall_x = 0;

--- a/seg006.c
+++ b/seg006.c
@@ -37,7 +37,7 @@ int __pascal far get_tile(int room,int col,int row) {
 		curr_tile2 = curr_room_tiles[curr_tilepos] & 0x1F;
 	} else {
 		// wall in room 0
-		curr_tile2 = tiles_20_wall;
+		curr_tile2 = level_edge_hit_tile; // tiles_20_wall
 	}
 	return curr_tile2;
 }

--- a/seg008.c
+++ b/seg008.c
@@ -341,7 +341,7 @@ void __pascal far load_curr_and_left_tile() {
 	word tiletype;
 	tiletype = tiles_20_wall;
 	if (drawn_row == 2) {
-		tiletype = tiles_1_floor; // floor at top of level
+		tiletype = drawn_tile_top_level_edge; // floor at top of level (default: tiles_1_floor)
 	}
 	get_tile_to_draw(drawn_room, drawn_col, drawn_row, &curr_tile, &curr_modifier, tiletype);
 	get_tile_to_draw(drawn_room, drawn_col - 1, drawn_row, &tile_left, &modifier_left, tiletype);
@@ -353,8 +353,8 @@ void __pascal far load_leftroom() {
 	word row;
 	get_room_address(room_L);
 	for (row = 0; row < 3; ++row) {
-		// wall at left of level
-		get_tile_to_draw(room_L, 9, row, &leftroom_[row].tiletype, &leftroom_[row].modifier, tiles_20_wall);
+		// wall at left of level (drawn_tile_left_level_edge), default: tiles_20_wall
+		get_tile_to_draw(room_L, 9, row, &leftroom_[row].tiletype, &leftroom_[row].modifier, drawn_tile_left_level_edge);
 	}
 }
 

--- a/seg008.c
+++ b/seg008.c
@@ -538,7 +538,7 @@ void __pascal far draw_tile_bottom(word arg_0) {
 	chtab_id = id_chtab_6_environment;
 	switch (curr_tile) {
 		case tiles_20_wall:
-			if (tbl_level_type[current_level] == 0 || graphics_mode != gmMcgaVga) {
+			if (tbl_level_type[current_level] == 0 || enable_wda_in_palace || graphics_mode != gmMcgaVga) {
 				id = wall_fram_bottom[curr_modifier & 0x7F];
 			}
 			chtab_id = id_chtab_7_environmentwall;
@@ -667,7 +667,7 @@ void __pascal far draw_tile_fore() {
 			}
 			break;
 		case tiles_20_wall:
-			if (tbl_level_type[current_level] == 0 || graphics_mode != gmMcgaVga) {
+			if (tbl_level_type[current_level] == 0 || enable_wda_in_palace || graphics_mode != gmMcgaVga) {
 				add_foretable(id_chtab_7_environmentwall, wall_fram_main[curr_modifier & 0x7F], draw_xh, 0, draw_main_y, blitters_0_no_transp, 0);
 			}
 			if (graphics_mode != gmCga && graphics_mode != gmHgaHerc) {
@@ -1848,7 +1848,7 @@ void __pascal far wall_pattern(int which_part,int which_table) {
 	// set the new seed
 	random_seed = drawn_room + tbl_line[drawn_row] + drawn_col;
 	prandom(1); // fetch a random number and discard it
-	is_dungeon = (tbl_level_type[current_level] < DESIGN_PALACE);
+	is_dungeon = (tbl_level_type[current_level] < DESIGN_PALACE) || enable_wda_in_palace;
 	if ( (!is_dungeon) && (graphics_mode== GRAPHICS_VGA) ) {
 		// I haven't traced the palace WDA
 		//[...]


### PR DESCRIPTION
This implements a few of the missing CusPop options:

* Start upside down
* Start in blind mode (slightly buggy)
* Set level before which the copy protection level appears
* Set up edges of the level
* Set up WDA in palace environment

Also slightly changed the formatting of the options in `[CustomGameplay]`:
* Commented out the options so they are not parsed by default
* Set the default value to the actual number, for the numerical options
(It was a bit strange/inconsistent that the numberical options had a value of 'default' (i.e. "ignore this option") while the boolean options had a value of 'false' (meaning either "ignore this option" or "disable this option"); hopefully, simply commenting out the custom options in the ini file makes it a little clearer...)

These CusPop options are not (yet) implemented:
* Set up colors
* Set up title screen skipping
* Set up the effect of Shift+L in non-cheat mode
* Set up file names (perhaps not necessary?)
* Set up game messages
* Set up quitting when time expires
* Set up allowed resources per level (unnecessary?)
* Set up cutscenes
* Set up number of hit points of the Prince on the demo level
* Set up demo level ending screen
* Set up level 1 crouching start
* Set up level 1 music
* Set up sword
* Set up level 3 checkpoint
* Set up the skeleton
* Set up the mirror
* Set up mirror image
* Set up falling exit
* Set up falling entry
* Set up the mouse
* Set up level 12 ending
* Set up loose tiles in level 12
* Set up Jaffar/guard death: blinking and event trigger
* Set up Jaffar
* Set up the winning screen
* Set up the controls (not sure how this should be handled?)
* Set up making the demo level playable
* Set up the first and last level accessible by cheat parameter
* Set up skill-specific extra guard hit points
* Set up cheat code argument (should leave this out perhaps?)