### PR TITLE
Separate PRINCE.HOF for each custom levelset

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -27,6 +27,8 @@ The authors of this program may be contacted at http://forum.princed.org
 #define strcasecmp _stricmp
 #endif
 
+#define POP_MAX_PATH 256
+
 #define WINDOW_TITLE "Prince of Persia (SDLPoP) v1.16"
 
 // Enable or disable fading.

--- a/src/data.h
+++ b/src/data.h
@@ -584,7 +584,7 @@ extern byte start_fullscreen INIT(= 0);
 extern word pop_window_width INIT(= 640);
 extern word pop_window_height INIT(= 400);
 extern byte use_custom_levelset INIT(= 0);
-extern char levelset_name[256];
+extern char levelset_name[POP_MAX_PATH];
 
 // Custom Gameplay settings
 extern word start_minutes_left INIT(= 60);

--- a/src/options.c
+++ b/src/options.c
@@ -360,7 +360,7 @@ void load_options() {
 
     // load mod-specific INI configuration
     if (use_custom_levelset) {
-        char filename[256];
+        char filename[POP_MAX_PATH];
         snprintf(filename, sizeof(filename), "mods/%s/%s", levelset_name, "mod.ini");
         ini_load(filename, mod_ini_callback);
     }

--- a/src/seg001.c
+++ b/src/seg001.c
@@ -731,29 +731,29 @@ void __pascal far show_hof() {
 	// stub
 }
 
-static const char* hof_path = "PRINCE.HOF";
+static const char* hof_file = "PRINCE.HOF";
+
+const char* get_hof_path(char* custom_path_buffer, size_t max_len) {
+	if (!use_custom_levelset) {
+		return hof_file;
+	}
+	// if playing a custom levelset, try to use the mod folder
+	snprintf(custom_path_buffer, max_len, "mods/%s/%s", levelset_name, hof_file /*PRINCE.HOF*/ );
+	return custom_path_buffer;
+}
 
 // seg001:0F17
 void __pascal far hof_write() {
 	int handle;
 	char custom_hof_path[POP_MAX_PATH];
-	char* path;
-
-	if (!use_custom_levelset) {
-		path = (char*) hof_path; // default PRINCE.HOF in the main folder
-	} else {
-		// if playing a custom levelset, try to use the mod folder
-		path = custom_hof_path;
-		snprintf(path, sizeof(custom_hof_path), "mods/%s/%s", levelset_name, hof_path /*PRINCE.HOF*/ );
-	}
-
+	const char* hof_path = get_hof_path(custom_hof_path, sizeof(custom_hof_path));
 	// no O_TRUNC
-	handle = open(path, O_WRONLY | O_CREAT | O_BINARY, 0600);
+	handle = open(hof_path, O_WRONLY | O_CREAT | O_BINARY, 0600);
 	if (handle < 0 ||
 	    write(handle, &hof_count, 2) != 2 ||
 	    write(handle, &hof, sizeof(hof)) != sizeof(hof) ||
 	    close(handle))
-		perror(path);
+		perror(hof_path);
 	if (handle >= 0)
 		close(handle);
 }
@@ -763,22 +763,13 @@ void __pascal far hof_read() {
 	int handle;
 	hof_count = 0;
 	char custom_hof_path[POP_MAX_PATH];
-	char* path;
-
-	if (!use_custom_levelset) {
-		path = (char*) hof_path; // default PRINCE.HOF in the main folder
-	} else {
-		// if playing a custom levelset, try to use the mod folder
-		path = custom_hof_path;
-		snprintf(path, sizeof(custom_hof_path), "mods/%s/%s", levelset_name, hof_path /*PRINCE.HOF*/ );
-	}
-
-	handle = open(path, O_RDONLY | O_BINARY);
+	const char* hof_path = get_hof_path(custom_hof_path, sizeof(custom_hof_path));
+	handle = open(hof_path, O_RDONLY | O_BINARY);
 	if (handle < 0)
 		return;
 	if (read(handle, &hof_count, 2) != 2 ||
 	    read(handle, &hof, sizeof(hof)) != sizeof(hof)) {
-		perror(path);
+		perror(hof_path);
 		hof_count = 0;
 	}
 }

--- a/src/seg001.c
+++ b/src/seg001.c
@@ -736,13 +736,24 @@ static const char* hof_path = "PRINCE.HOF";
 // seg001:0F17
 void __pascal far hof_write() {
 	int handle;
+	char custom_hof_path[POP_MAX_PATH];
+	char* path;
+
+	if (!use_custom_levelset) {
+		path = (char*) hof_path; // default PRINCE.HOF in the main folder
+	} else {
+		// if playing a custom levelset, try to use the mod folder
+		path = custom_hof_path;
+		snprintf(path, sizeof(custom_hof_path), "mods/%s/%s", levelset_name, hof_path /*PRINCE.HOF*/ );
+	}
+
 	// no O_TRUNC
-	handle = open(hof_path, O_WRONLY | O_CREAT | O_BINARY, 0600);
+	handle = open(path, O_WRONLY | O_CREAT | O_BINARY, 0600);
 	if (handle < 0 ||
 	    write(handle, &hof_count, 2) != 2 ||
 	    write(handle, &hof, sizeof(hof)) != sizeof(hof) ||
 	    close(handle))
-		perror(hof_path);
+		perror(path);
 	if (handle >= 0)
 		close(handle);
 }
@@ -751,12 +762,23 @@ void __pascal far hof_write() {
 void __pascal far hof_read() {
 	int handle;
 	hof_count = 0;
-	handle = open(hof_path, O_RDONLY | O_BINARY);
+	char custom_hof_path[POP_MAX_PATH];
+	char* path;
+
+	if (!use_custom_levelset) {
+		path = (char*) hof_path; // default PRINCE.HOF in the main folder
+	} else {
+		// if playing a custom levelset, try to use the mod folder
+		path = custom_hof_path;
+		snprintf(path, sizeof(custom_hof_path), "mods/%s/%s", levelset_name, hof_path /*PRINCE.HOF*/ );
+	}
+
+	handle = open(path, O_RDONLY | O_BINARY);
 	if (handle < 0)
 		return;
 	if (read(handle, &hof_count, 2) != 2 ||
 	    read(handle, &hof, sizeof(hof)) != sizeof(hof)) {
-		perror(hof_path);
+		perror(path);
 		hof_count = 0;
 	}
 }

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -152,7 +152,7 @@ dat_type *__pascal open_dat(const char *filename,int drive) {
 		fp = fopen(filename, "rb");
 	}
 	else {
-		char filename_mod[256];
+		char filename_mod[POP_MAX_PATH];
 		// before checking the root directory, first try mods/MODNAME/
 		snprintf(filename_mod, sizeof(filename_mod), "mods/%s/%s", levelset_name, filename);
 		fp = fopen(filename_mod, "rb");
@@ -1636,7 +1636,7 @@ void load_sound_names() {
 	sound_names = (char**) calloc(sizeof(char*) * max_sound_id, 1);
 	while (!feof(fp)) {
 		int index;
-		char name[256];
+		char name[POP_MAX_PATH];
 		if (fscanf(fp, "%d=%255s\n", &index, /*sizeof(name)-1,*/ name) != 2) {
 			perror(names_path);
 			continue;
@@ -1673,7 +1673,7 @@ sound_buffer_type* load_sound(int index) {
 			const char* exts[]={"ogg","mp3","flac","wav"};
 			int i;
 			for (i = 0; i < COUNT(exts); ++i) {
-				char filename[256];
+				char filename[POP_MAX_PATH];
 				const char* ext=exts[i];
 				struct stat info;
 
@@ -2019,7 +2019,7 @@ int __pascal far get_text_color(int cga_color,int low_half,int high_half_mask) {
 }
 
 void load_from_opendats_metadata(int resource_id, const char* extension, FILE** out_fp, data_location* result, byte* checksum, int* size, dat_type** out_pointer) {
-	char image_filename[256];
+	char image_filename[POP_MAX_PATH];
 	FILE* fp = NULL;
 	dat_type* pointer;
 	*result = data_none;
@@ -2057,7 +2057,7 @@ void load_from_opendats_metadata(int resource_id, const char* extension, FILE** 
 				fp = fopen(image_filename, "rb");
 			}
 			else {
-				char image_filename_mod[256];
+				char image_filename_mod[POP_MAX_PATH];
 				// before checking data/, first try mods/MODNAME/data/
 				snprintf(image_filename_mod, sizeof(image_filename_mod), "mods/%s/%s", levelset_name, image_filename);
 				//printf("loading (binary) %s",image_filename_mod);

--- a/src/types.h
+++ b/src/types.h
@@ -407,7 +407,7 @@ SDL_COMPILE_TIME_ASSERT(image_data_size, sizeof(image_data_type) == 6);
 typedef struct dat_type {
 	struct dat_type* next_dat;
 	FILE* handle;
-	char filename[64];
+	char filename[POP_MAX_PATH];
 	dat_table_type* dat_table;
 	// handle and dat_table are NULL if the DAT is a directory.
 } dat_type;


### PR DESCRIPTION
This adds a way to use a separate Hall of Fame when playing custom levelsets. So the record times do not get mixed up when switching to another mod.
To achieve this the game will try to write and read PRINCE.HOF within the mod's own folder, instead of the base folder.

I also added a macro `POP_MAX_PATH` for the maximum path length.
N.B. This changes `dat_type`: I made the `char filename[64]` field longer, so that it is also consistent with other places in the code (everywhere else I could find, the max supported path length was 256 bytes).
As far as I can tell this change does not seem to cause any problems.