### PR TITLE
Allow disabling the time limit completely

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -161,6 +161,7 @@ fix_jump_through_wall_above_gate = false
 
 [CustomGameplay]
 ; Starting minutes left. (default = 60)
+; To disable the time limit completely, set this to -1.
 ;start_minutes_left = 60
 
 ; Starting number of ticks left in the first minute. (default = 719)

--- a/src/config.h
+++ b/src/config.h
@@ -83,6 +83,12 @@ The authors of this program may be contacted at http://forum.princed.org
 // Allow guard hitpoints not resetting to their default (maximum) value when re-entering the room
 #define REMEMBER_GUARD_HP
 
+// Enable completely disabling the time limit. To use this feature, set the starting time to -1.
+// This also disables the in-game messages that report how much time is left every minute.
+// The elasped time is still kept track of, so that the shortest times will appear in the Hall of Fame.
+#define ALLOW_INFINITE_TIME
+
+
 // Bugfixes:
 
 // The mentioned tricks can be found here: http://www.popot.org/documentation.php?doc=Tricks

--- a/src/data.h
+++ b/src/data.h
@@ -46,7 +46,7 @@ extern word resurrect_time;
 // data:42B4
 extern word dont_reset_time;
 // data:4F7E
-extern word rem_min;
+extern short rem_min;
 // data:4F82
 extern word rem_tick;
 // data:4608

--- a/src/seg001.c
+++ b/src/seg001.c
@@ -724,7 +724,22 @@ void __pascal far show_hof() {
 	short index;
 	char time_text[12];
 	for (index = 0; index < hof_count; ++index) {
+
+#ifdef ALLOW_INFINITE_TIME
+		int minutes, seconds;
+		if (hof[index].min > 0) {
+			minutes = hof[index].min - 1;
+			seconds = hof[index].tick / 12;
+		} else {
+			// negative minutes means time ran 'forward' from 0:00 upwards
+			minutes = abs(hof[index].min) - 1;
+			seconds = (719 - hof[index].tick) / 12;
+		}
+		snprintf(time_text, sizeof(time_text), "%d:%02d", minutes, seconds);
+#else
 		snprintf(time_text, sizeof(time_text), "%d:%02d", hof[index].min - 1, hof[index].tick / 12);
+#endif
+
 		show_hof_text(&hof_rects[index], -1, 0, hof[index].name);
 		show_hof_text(&hof_rects[index], 1, 0, time_text);
 	}

--- a/src/seg003.c
+++ b/src/seg003.c
@@ -349,7 +349,11 @@ int __pascal far play_level_2() {
 				#ifdef USE_DEBUG_CHEATS
                 if (debug_cheats_enabled && is_timer_displayed) {
 					char timer_text[16];
-					snprintf(timer_text, 16, "%02d:%02d:%02d", rem_min - 1, rem_tick / 12, rem_tick % 12);
+					if (rem_min < 0) {
+						snprintf(timer_text, 16, "%02d:%02d:%02d", -(rem_min + 1), (719 - rem_tick) / 12, (719 - rem_tick) % 12);
+					} else {
+						snprintf(timer_text, 16, "%02d:%02d:%02d", rem_min - 1, rem_tick / 12, rem_tick % 12);
+					}
 					screen_updates_suspended = 1;
 					draw_rect(&timer_rect, color_0_black);
 					show_text(&timer_rect, -1, -1, timer_text);

--- a/src/seg008.c
+++ b/src/seg008.c
@@ -1689,6 +1689,10 @@ void __pascal far show_time() {
 		#ifdef FREEZE_TIME_DURING_END_MUSIC
 		(!(options.enable_freeze_time_during_end_music && next_level != current_level)) &&
 		#endif
+		#ifdef ALLOW_INFINITE_TIME
+		// prevent overflow
+		(!(rem_min == INT16_MIN && rem_tick == 1)) &&
+		#endif
 		rem_min != 0 &&
 		(current_level < 13 || (current_level == 13 && leveldoor_open == 0)) &&
 		current_level < 15
@@ -1724,6 +1728,11 @@ void __pascal far show_time() {
 			}
 			display_text_bottom(sprintf_temp);
 		} else {
+
+#ifdef ALLOW_INFINITE_TIME
+			if (rem_min == 0) // may also be negative, don't report "expired" in that case!
+#endif
+
 			display_text_bottom("TIME HAS EXPIRED!");
 		}
 		is_show_time = 0;


### PR DESCRIPTION
By setting `start_minutes_left` to -1 (or another negative number) the time limit can be disabled.
This also disables the in-game messages that report how much time is left every minute.
The elasped time is still kept track of, so that the shortest times will appear in the Hall of Fame (in ascending order, counting upwards from 0:00).
I changed the `rem_min` to a signed short integer to make this work.
(I wonder if `rem_min` was signed in the original DOS source... At least I suppose they did not count on large values, because they used a (signed) `%d` in the formatting string `%d MINUTES LEFT`)