### PR TITLE
Use Mix_Music instead of Mix_Chunk to play music files.

### DIFF
--- a/src/seg009.c
+++ b/src/seg009.c
@@ -1496,6 +1496,7 @@ void stop_digi() {
 	SDL_UnlockAudio();
 #else
 	Mix_HaltChannel(-1);
+	Mix_HaltMusic();
 	digi_playing = 0;
 #endif
 }
@@ -1586,6 +1587,9 @@ void channel_finished(int channel) {
 	event.user.code = userevent_SOUND;
 	SDL_PushEvent(&event);
 }
+void music_finished() {
+	channel_finished(-1);
+}
 #endif
 
 int digi_unavailable = 0;
@@ -1619,6 +1623,7 @@ void init_digi() {
 	}
 	Mix_AllocateChannels(1);
 	Mix_ChannelFinished(channel_finished);
+	Mix_HookMusicFinished(music_finished);
 #endif
 	digi_audiospec = desired;
 }
@@ -1682,16 +1687,16 @@ sound_buffer_type* load_sound(int index) {
 				if (stat(filename, &info))
 					continue;
 				//printf("Trying to load %s\n", filename);
-				Mix_Chunk* chunk = Mix_LoadWAV(filename);
-				if (chunk == NULL) {
+				Mix_Music* music = Mix_LoadMUS(filename);
+				if (music == NULL) {
 					sdlperror(filename);
 					//sdlperror("Mix_LoadWAV");
 					continue;
 				}
 				//printf("Loaded sound from %s\n", filename);
 				result = malloc(sizeof(sound_buffer_type));
-				result->type = sound_chunk;
-				result->chunk = chunk;
+				result->type = sound_music;
+				result->music = music;
 				break;
 			}
 		} else {
@@ -1721,6 +1726,16 @@ void __pascal far play_chunk_sound(sound_buffer_type far *buffer) {
 	//printf("playing chunk sound %p\n", buffer);
 	if (Mix_PlayChannel(sound_channel, buffer->chunk, 0) == -1) {
 		sdlperror("Mix_PlayChannel");
+	}
+	digi_playing = 1;
+}
+
+void __pascal far play_music_sound(sound_buffer_type far *buffer) {
+	init_digi();
+	if (digi_unavailable) return;
+	stop_sounds();
+	if (Mix_PlayMusic(buffer->music, 0) == -1) {
+		sdlperror("Mix_PlayMusic");
 	}
 	digi_playing = 1;
 }
@@ -1846,6 +1861,9 @@ void free_sound(sound_buffer_type far *buffer) {
 	if (buffer->type == sound_chunk) {
 		Mix_FreeChunk(buffer->chunk);
 	}
+	if (buffer->type == sound_music) {
+		Mix_FreeMusic(buffer->music);
+	}
 #endif
 	free(buffer);
 }
@@ -1858,7 +1876,7 @@ void __pascal far play_sound_from_buffer(sound_buffer_type far *buffer) {
 		//quit(1);
 		return;
 	}
-	switch (buffer->type & 3) {
+	switch (buffer->type & 7) {
 		case sound_speaker:
 			play_speaker_sound(buffer);
 		break;
@@ -1868,6 +1886,9 @@ void __pascal far play_sound_from_buffer(sound_buffer_type far *buffer) {
 #ifdef USE_MIXER
 		case sound_chunk:
 			play_chunk_sound(buffer);
+		break;
+		case sound_music:
+			play_music_sound(buffer);
 		break;
 #endif
 		default:

--- a/src/types.h
+++ b/src/types.h
@@ -473,6 +473,7 @@ typedef enum data_location {
 enum sound_type {
 #ifdef USE_MIXER
 	sound_chunk = 3,
+	sound_music = 4,
 #endif
 	sound_speaker = 0,
 	sound_digi = 1,
@@ -522,6 +523,7 @@ typedef struct sound_buffer_type {
 		midi_type midi;
 #ifdef USE_MIXER
 		Mix_Chunk *chunk;
+		Mix_Music *music;
 #endif
 	};
 } sound_buffer_type;


### PR DESCRIPTION
Mix_Music is designed to play musics instead of Mix_Chunk which is for samples (sounds and effects).
The main effect is to reduce loading time.

More explanations can be found here: https://github.com/usineur/SDLPoP-Vita/commit/41bf6310c203a487d6e67ea4f7caa71387d7f707