### PR TITLE
Another fix for gate drawing bug

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -65,7 +65,7 @@ replays_folder = replays
 
 
 [Enhancements]
-use_fixes_and_enhancements = false
+use_fixes_and_enhancements = true
 
 ;    'prompt' --> the game will ask each time the game is launched
 ;    'true'   --> fixes and enhancements are used
@@ -96,8 +96,7 @@ fix_two_coll_bug = true
 fix_infinite_down_bug = true
 
 ; When a gate is under another gate, the top of the bottom gate is not visible.
-; But this fix causes a drawing bug when a gate opens.
-fix_gate_drawing_bug = false
+fix_gate_drawing_bug = true
 
 ; When climbing up to a floor with a big pillar top behind, turned right, Kid sees through floor.
 ; The current fix causes glitches you can see on bug_chomper.PNG and bug_climb.PNG .

--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -166,6 +166,9 @@ fix_push_guard_into_wall = true
 ; By doing a running jump into a wall, you can fall behind a closed gate two floors down. (e.g. skip in Level 7)
 fix_jump_through_wall_above_gate = true
 
+; If you grab a ledge that is one or more floors down, the chompers on that row will not start.
+fix_chompers_not_starting = true
+
 
 
 [CustomGameplay]

--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -99,8 +99,7 @@ fix_infinite_down_bug = true
 fix_gate_drawing_bug = true
 
 ; When climbing up to a floor with a big pillar top behind, turned right, Kid sees through floor.
-; The current fix causes glitches you can see on bug_chomper.PNG and bug_climb.PNG .
-fix_bigpillar_climb = false
+fix_bigpillar_climb = true
 
 ; When climbing up two floors, turning around and jumping upward, the kid falls down.
 ; This fix makes the workaround of Trick 25 unnecessary.

--- a/doc/mod.ini
+++ b/doc/mod.ini
@@ -54,8 +54,7 @@
 ;fix_infinite_down_bug = true
 
 ; When a gate is under another gate, the top of the bottom gate is not visible.
-; But this fix causes a drawing bug when a gate opens.
-;fix_gate_drawing_bug = false
+;fix_gate_drawing_bug = true
 
 ; When climbing up to a floor with a big pillar top behind, turned right, Kid sees through floor.
 ; The current fix causes glitches you can see on bug_chomper.PNG and bug_climb.PNG .

--- a/doc/mod.ini
+++ b/doc/mod.ini
@@ -125,6 +125,9 @@
 ; By doing a running jump into a wall, you can fall behind a closed gate two floors down. (e.g. skip in Level 7)
 ;fix_jump_through_wall_above_gate = true
 
+; If you grab a ledge that is one or more floors down, the chompers on that row will not start.
+;fix_chompers_not_starting = true
+
 [CustomGameplay]
 ; Starting minutes left. (default = 60)
 ; To disable the time limit completely, set this to -1.

--- a/src/config.h
+++ b/src/config.h
@@ -110,8 +110,7 @@ The authors of this program may be contacted at http://forum.princed.org
 #define FIX_GATE_DRAWING_BUG
 
 // When climbing up to a floor with a big pillar top behind, turned right, Kid sees through floor.
-// The current fix causes glitches you can see on bug_chomper.PNG and bug_climb.PNG .
-//#define FIX_BIGPILLAR_CLIMB
+#define FIX_BIGPILLAR_CLIMB
 
 // When climbing up two floors, turning around and jumping upward, the kid falls down.
 // This fix makes the workaround of Trick 25 unnecessary.

--- a/src/config.h
+++ b/src/config.h
@@ -107,7 +107,7 @@ The authors of this program may be contacted at http://forum.princed.org
 
 // When a gate is under another gate, the top of the bottom gate is not visible.
 // But this fix causes a drawing bug when a gate opens.
-//#define FIX_GATE_DRAWING_BUG
+#define FIX_GATE_DRAWING_BUG
 
 // When climbing up to a floor with a big pillar top behind, turned right, Kid sees through floor.
 // The current fix causes glitches you can see on bug_chomper.PNG and bug_climb.PNG .

--- a/src/config.h
+++ b/src/config.h
@@ -177,6 +177,10 @@ The authors of this program may be contacted at http://forum.princed.org
 // By doing a running jump into a wall, you can fall behind a closed gate two floors down. (e.g. skip in Level 7)
 #define FIX_JUMP_THROUGH_WALL_ABOVE_GATE
 
+// If you grab a ledge that is one or more floors down, the chompers on that row will not start.
+#define FIX_CHOMPERS_NOT_STARTING
+
+
 // Debug features:
 
 // When the program starts, check whether the deobfuscated sequence table (seqtbl.c) is correct.

--- a/src/data.h
+++ b/src/data.h
@@ -625,6 +625,7 @@ extern byte fix_retreat_without_leaving_room INIT(= 1);
 extern byte fix_running_jump_through_tapestry INIT(= 1);
 extern byte fix_push_guard_into_wall INIT(= 1);
 extern byte fix_jump_through_wall_above_gate INIT(= 1);
+extern byte fix_chompers_not_starting INIT(= 1);
 
 // Custom Gameplay settings
 extern word start_minutes_left INIT(= 60);

--- a/src/options.c
+++ b/src/options.c
@@ -71,6 +71,7 @@ void options_process(SDL_RWops* rw, rw_process_func_type process_func) {
     process(fix_running_jump_through_tapestry);
     process(fix_push_guard_into_wall);
     process(fix_jump_through_wall_above_gate);
+    process(fix_chompers_not_starting);
     process(start_minutes_left);
     process(start_ticks_left);
     process(start_hitp);
@@ -142,6 +143,7 @@ void disable_fixes_and_enhancements() {
     fix_running_jump_through_tapestry= 0;
     fix_push_guard_into_wall = 0;
     fix_jump_through_wall_above_gate = 0;
+    fix_chompers_not_starting = 0;
 }
 
 // .ini file parser adapted from https://gist.github.com/OrangeTide/947070
@@ -352,6 +354,7 @@ static int global_ini_callback(const char *section, const char *name, const char
         process_boolean("fix_running_jump_through_tapestry", &fix_running_jump_through_tapestry);
         process_boolean("fix_push_guard_into_wall", &fix_push_guard_into_wall);
         process_boolean("fix_jump_through_wall_above_gate", &fix_jump_through_wall_above_gate);
+        process_boolean("fix_chompers_not_starting", &fix_chompers_not_starting);
     }
 
     if (check_ini_section("CustomGameplay")) {

--- a/src/seg006.c
+++ b/src/seg006.c
@@ -1087,6 +1087,9 @@ void __pascal far check_grab() {
 			grab_timer = 12;
 			play_sound(sound_9_grab); // grab
 			is_screaming = 0;
+#ifdef FIX_CHOMPERS_NOT_STARTING
+			if (fix_chompers_not_starting) start_chompers();
+#endif
 		}
 	}
 }

--- a/src/seg008.c
+++ b/src/seg008.c
@@ -1070,17 +1070,21 @@ void __pascal far draw_gate_back() {
 	if (gate_bottom_y + 12 < draw_main_y) {
 		add_backtable(id_chtab_6_environment, 50 /*gate bottom with B*/, draw_xh, 0, gate_bottom_y, blitters_0_no_transp, 0);
 	} else {
-#ifndef FIX_GATE_DRAWING_BUG
 		// The following line (erroneously) erases the top-right of the tile below-left (because it is drawn non-transparently).
 		// -- But it draws something that was already drawn! (in draw_tile_right()).
-		add_backtable(id_chtab_6_environment, tile_table[tiles_4_gate].right_id, draw_xh, 0, tile_table[tiles_4_gate].right_y + draw_main_y, blitters_0_no_transp, 0);
+		add_backtable(id_chtab_6_environment, tile_table[tiles_4_gate].right_id, draw_xh, 0,
+					  tile_table[tiles_4_gate].right_y + draw_main_y, blitters_0_no_transp, 0);
 		// And this line tries to fix it. But it fails if it was a gate or a pillar.
 		if (can_see_bottomleft()) draw_tile_topright();
+#ifdef FIX_GATE_DRAWING_BUG
+		if (fix_gate_drawing_bug) {
+			draw_tile_anim_topright(); // redraw the erased top-right section of the gate below-left
+		}
+#endif
 		// The following 3 lines draw things that are drawn after this anyway.
 		draw_tile_bottom(0);
 		draw_loose(0);
 		draw_tile_base();
-#endif
 		add_backtable(id_chtab_6_environment, 51 /*gate bottom*/, draw_xh, 0, gate_bottom_y - 2, blitters_10h_transp, 0);
 	}
 	ybottom = gate_bottom_y - 12;

--- a/src/seg008.c
+++ b/src/seg008.c
@@ -1401,7 +1401,15 @@ const word floor_left_overlay[] = {32, 151, 151, 150, 150, 151, 32, 32};
 
 // seg008:1E3A
 void __pascal far draw_floor_overlay() {
-#ifndef FIX_BIGPILLAR_CLIMB
+#ifdef FIX_BIGPILLAR_CLIMB
+	if (tile_left != tiles_0_empty) {
+		// Bug: When climbing up to a floor with a big pillar top behind, turned right, Kid sees through floor.
+		// The bigpillar_top tile should be treated similarly to an empty tile here.
+		if (!fix_bigpillar_climb || (tile_left != tiles_9_bigpillar_top)) {
+			return;
+		}
+	}
+#else
 	if (tile_left != tiles_0_empty) return;
 #endif
 	if (curr_tile == tiles_1_floor ||


### PR DESCRIPTION
This is another version of the fix for the gate drawing bug that occurs when multiple gates are stacked on top of each other.
Calls `draw_tile_anim_topright()` to redraw the erased part of the gate. Luckily, the animation when the gate opens still works correctly this way.

I also tried to restore FIX_BIGPILLAR_CLIMB, but as it says in bugs.txt and in the code comments, "The current fix causes glitches you can see on bug_chomper.PNG and bug_climb.PNG".
Unfortunately I couldn't find back these images, so I can't really verify that the glitches are fixed...
But, this may be a possible fix...?

```
// seg008:1E3A
void __pascal far draw_floor_overlay() {
#ifdef FIX_BIGPILLAR_CLIMB
    if (tile_left != tiles_0_empty) {
        // Bug: When climbing up to a floor with a big pillar top behind, turned right, Kid sees through floor.
        // The bigpillar_top tile should be treated similarly to an empty tile here.
        if (!fix_bigpillar_climb || (tile_left != tiles_9_bigpillar_top)) {
            return;
        }
    }
#else
    if (tile_left != tiles_0_empty) return;
#endif
```
