### PR TITLE
Improved controller support; migrated to SDL_GameController API

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -39,6 +39,10 @@ pop_window_height = default
 ; NB. Works best using a high resolution.
 use_correct_aspect_ratio = false
 
+; When using a controller, only use the joysticks for horizontal movement (instead of all-directional movement).
+; This could make the game easier to control, depending on your preference and depending on which controller you have.
+joystick_only_horizontal = true
+
 ; You can choose which levels to play using the 'levelset' option:
 ;    'original'       --> play the original levels (Default)
 ;    'Your Mod Name'  --> play a custom levelset (the custom files must be in a directory "mods/Your Mod Name/")

--- a/src/data.h
+++ b/src/data.h
@@ -524,9 +524,14 @@ extern SDL_Surface* onscreen_surface_;
 extern SDL_Renderer* renderer_;
 extern SDL_Window* window_;
 extern SDL_Texture* sdl_texture_;
-extern SDL_Joystick* sdl_controller_ INIT( = 0 );
 
-extern int gamepad_states[3] INIT( = { 0, 0, 0 } ); // hor, ver, shift
+extern SDL_GameController* sdl_controller_ INIT( = 0 );
+extern int joy_axis[6]; // hor/ver axes for left/right sticks + left and right triggers (in total 6 axes)
+extern int joy_left_stick_states[2]; // horizontal, vertical
+extern int joy_right_stick_states[2];
+extern int joy_hat_states[2]; // horizontal, vertical
+extern int joy_AY_buttons_state;
+extern int joy_X_button_state;
 
 extern int screen_updates_suspended;
 

--- a/src/data.h
+++ b/src/data.h
@@ -598,6 +598,7 @@ extern byte enable_mixer INIT(= 1);
 extern byte enable_fade INIT(= 1);
 extern byte enable_flash INIT(= 1);
 extern byte enable_text INIT(= 1);
+extern byte joystick_only_horizontal INIT(= 0);
 extern byte enable_quicksave INIT(= 1);
 extern byte enable_quicksave_penalty INIT(= 1);
 extern byte enable_replay INIT(= 1);

--- a/src/options.c
+++ b/src/options.c
@@ -292,6 +292,7 @@ static int global_ini_callback(const char *section, const char *name, const char
         process_word("pop_window_width", &pop_window_width, NULL);
         process_word("pop_window_height", &pop_window_height, NULL);
         process_boolean("use_correct_aspect_ratio", &use_correct_aspect_ratio);
+        process_boolean("joystick_only_horizontal", &joystick_only_horizontal);
 
         if (strcasecmp(name, "levelset") == 0) {
             if (value[0] == '\0' || strcasecmp(value, "original") == 0 || strcasecmp(value, "default") == 0) {

--- a/src/seg005.c
+++ b/src/seg005.c
@@ -424,6 +424,22 @@ void __pascal far control_turning() {
 	if (control_shift >= 0 && control_x < 0 && control_y >= 0) {
 		seqtbl_offset_char(seq_43_start_run_after_turn); // start run and run (after turning)
 	}
+
+	// Added:
+	// When using a joystick, the kid may sometimes jump/duck/turn unintendedly after turning around.
+	// To prevent this: clear the remembered controls, so that if the stick has already moved to another/neutral position,
+	// the kid will not jump, duck, or turn again.
+	if (is_joyst_mode) {
+		if (control_up < 0 && control_y >= 0) {
+			control_up = 0;
+		}
+		if (control_down < 0 && control_y <= 0) {
+			control_down = 0;
+		}
+		if (control_backward < 0 && control_x == 0) {
+			control_backward = 0;
+		}
+	}
 }
 
 // seg005:05AD

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -606,7 +606,7 @@ int __pascal far set_joy_mode() {
 	if (SDL_NumJoysticks() < 1) {
 		is_joyst_mode = 0;
 	} else {
-		sdl_controller_ = SDL_JoystickOpen( 0 );
+		sdl_controller_ = SDL_GameControllerOpen(0);
 		if (sdl_controller_ == NULL) {
 			is_joyst_mode = 0;
 		} else {
@@ -1936,7 +1936,7 @@ int __pascal far check_sound_playing() {
 
 // seg009:38ED
 void __pascal far set_gr_mode(byte grmode) {
-	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_NOPARACHUTE | SDL_INIT_JOYSTICK ) != 0) {
+	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_NOPARACHUTE | SDL_INIT_GAMECONTROLLER ) != 0) {
 		sdlperror("SDL_Init");
 		quit(1);
 	}
@@ -2593,75 +2593,45 @@ void idle() {
 			case SDL_KEYUP:
 				key_states[event.key.keysym.scancode] = 0;
 				break;
+			case SDL_CONTROLLERAXISMOTION:
+				if (event.caxis.axis < 6) joy_axis[event.caxis.axis] = event.caxis.value;
+				break;
+			case SDL_CONTROLLERBUTTONDOWN:
+				switch (event.cbutton.button)
+				{
+					case SDL_CONTROLLER_BUTTON_DPAD_LEFT:  joy_hat_states[0] = -1; break; // left
+					case SDL_CONTROLLER_BUTTON_DPAD_RIGHT: joy_hat_states[0] = 1;  break; // right
+					case SDL_CONTROLLER_BUTTON_DPAD_UP:    joy_hat_states[1] = -1; break; // up
+					case SDL_CONTROLLER_BUTTON_DPAD_DOWN:  joy_hat_states[1] = 1;  break; // down
 
-			case SDL_JOYAXISMOTION:
-				if (event.jaxis.axis == 0) {
+					case SDL_CONTROLLER_BUTTON_A:          joy_AY_buttons_state = 1;  break; /*** A (down) ***/
+					case SDL_CONTROLLER_BUTTON_Y:          joy_AY_buttons_state = -1; break; /*** Y (up) ***/
+					case SDL_CONTROLLER_BUTTON_X:          joy_X_button_state = 1;    break; /*** X (shift) ***/
 
-					if (event.jaxis.value < -8000)
-						gamepad_states[0] = -1;	// left
+					case SDL_CONTROLLER_BUTTON_START:
+						last_key_scancode = SDL_SCANCODE_R | WITH_CTRL; /*** start (restart game) ***/
+						break;
 
-					else if (event.jaxis.value > 8000)
-						gamepad_states[0] = 1; // right
+					case SDL_CONTROLLER_BUTTON_BACK:
+						last_key_scancode = SDL_SCANCODE_A | WITH_CTRL;  /*** back (restart level) ***/
+						break;
 
-					else
-						gamepad_states[0] = 0;
-				}
-
-				if (event.jaxis.axis == 1) {
-					if (event.jaxis.value < -8000)
-						gamepad_states[1] = -1; // up
-
-					else if (event.jaxis.value > 8000)
-						gamepad_states[1] = 1; // down
-
-					else
-						gamepad_states[1] = 0;
+					default: break;
 				}
 				break;
-			case SDL_JOYHATMOTION:
-				switch (event.jhat.value)
+			case SDL_CONTROLLERBUTTONUP:
+				switch (event.cbutton.button)
 				{
-					case 1: gamepad_states[1] = -1; break; // up
-					case 2: gamepad_states[0] = 1; break; // right
-					case 3: gamepad_states[0] = 1; gamepad_states[1] = -1; break; // right (and up)
-					case 4: gamepad_states[1] = 1; break;	// down
-					case 6: gamepad_states[0] = 1; gamepad_states[1] = 1; break; // right (and down)
-					case 8: gamepad_states[0] = -1; break; // left
-					case 9: gamepad_states[0] = -1; gamepad_states[1] = -1; break; // left (and up)
-					case 12: gamepad_states[0] = -1; gamepad_states[1] = 1; break; // left (and down)
-					default: gamepad_states[0] = 0; gamepad_states[1] = 0;  break;
-				}
-				break;
-			case SDL_JOYBUTTONDOWN:
-				switch (event.jbutton.button)
-				{
-					case 0: gamepad_states[1] = 1; break; /*** A (down) ***/
-					case 1: break; /*** B ***/
-					case 2: gamepad_states[2] = 1; break; /*** X (shift) ***/
-					case 3: gamepad_states[1] = -1; break; /*** Y (up) ***/
-					case 4: break; /*** left shoulder ***/
-					case 5: break; /*** right shoulder ***/
-					case 6: break; /*** back ***/
-					case 7: quit(0); break; /*** start (quit) ***/
-					case 8: break; /*** guide ***/
-					case 9: break; /*** left joystick ***/
-					case 10: break; /*** right joystick ***/
-				}
-				break;
-			case SDL_JOYBUTTONUP:
-				switch (event.jbutton.button)
-				{
-					case 0: gamepad_states[1] = 0; break; /*** A (down) ***/
-					case 1: break; /*** B ***/
-					case 2: gamepad_states[2] = 0; break; /*** X (shift) ***/
-					case 3: gamepad_states[1] = 0; break; /*** Y (up) ***/
-					case 4: break; /*** left shoulder ***/
-					case 5: break; /*** right shoulder ***/
-					case 6: break; /*** back ***/
-					case 7: break; /*** start ***/
-					case 8: break; /*** guide ***/
-					case 9: break; /*** left joystick ***/
-					case 10: break; /*** right joystick ***/
+					case SDL_CONTROLLER_BUTTON_DPAD_LEFT:  joy_hat_states[0] = 0; break; // left
+					case SDL_CONTROLLER_BUTTON_DPAD_RIGHT: joy_hat_states[0] = 0; break; // right
+					case SDL_CONTROLLER_BUTTON_DPAD_UP:    joy_hat_states[1] = 0; break; // up
+					case SDL_CONTROLLER_BUTTON_DPAD_DOWN:  joy_hat_states[1] = 0; break; // down
+
+					case SDL_CONTROLLER_BUTTON_A:          joy_AY_buttons_state = 0; break; /*** A (down) ***/
+					case SDL_CONTROLLER_BUTTON_Y:          joy_AY_buttons_state = 0; break; /*** Y (up) ***/
+					case SDL_CONTROLLER_BUTTON_X:          joy_X_button_state = 0;   break; /*** X (shift) ***/
+
+					default: break;
 				}
 				break;
 			case SDL_TEXTINPUT:


### PR DESCRIPTION
This improves the controller support in several ways, based on suggestions and earlier work by @EndeavourAccuracy and others:
- Migrated to the SDL_GameController API, which gives an abstraction layer over the controller mappings and may thus provide better compatibility with different controllers.
- Buttons and joysticks on the controller no longer interfere with each other's input (each button or axis should have its own state variable)
- Works with the joystick's angle instead of raw X/Y cutoffs
- In general, tweaked the responsiveness of the joystick controls - playing with a controller should be more pleasant. (tested using an Xbox 360 controller)
- Can now also use the triggers (both left and right) as Shift control.
- Start button now restarts the game (Similar to Ctrl+R), Back button restarts the level (Similar to Ctrl+A).
