### PR TITLE
Cleanup for version 1.17

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -69,7 +69,7 @@ replays_folder = replays
 
 
 [Enhancements]
-use_fixes_and_enhancements = true
+use_fixes_and_enhancements = false
 
 ;    'prompt' --> the game will ask each time the game is launched
 ;    'true'   --> fixes and enhancements are used

--- a/doc/ChangeLog.txt
+++ b/doc/ChangeLog.txt
@@ -306,86 +306,108 @@ DONE: Added support for named values in the INI file.
 DONE: Improved gamepad support.
 DONE: Added support for displaying the game with the original 4:3 aspect ratio.
 
-2016 September ??
+2016 November ??
 =================
 (version 1.17)
 
-CHANGE: Let time just run when quickloading immediately after quicksave
-DONE: OSX port upgraded from SDL to SDL2. Mixer library added in makefile and documentation. Tested.
+General changes:
+CHANGE: Moved source to src/. (That is, merged the with-folders branch into master.)
 DONE: Moved OSX documentation to Readme.txt. Upgraded information there. Removed TODO text for the SDL2 port.
-DONE: Merged both makefiles. Now make is fully portable.
-DONE: Added remembering guard hitpoints (optional fix/enhancement)
-FIXED: New movement fixes
-CHANGE: Updated CMakeLists.txt
-FIXED: Removed duplicate const to avoid warnings in default gcc settings on OSX. Commented an always-true if.
 DONE: Added sources and fake tiles to Readme.
-CHANGE: Updated OSX make command in Readme.
-DONE: Removed unneeded libraries from Dev-C++ projects.
 DONE: Added Markus installation method with brew install for OSX to the readme.
-DONE: Add OSX build configuration for CMake
-FIXED: config: compile with USE_MIXER undefined
-DONE: Removed RGB/BGR hack.
-DONE: Removed sudo as Markus remarks. Added another tested OSX version by DarkPrince.
-FIXED: Fixed crashing from guards on level 14.
+CHANGE: Updated OSX make command in Readme.
 DONE: Updated forum link in Readme.
-FIXED: Re-added RGB24 workaround with a check.
-FIXED: Added extern to all variables in data.h.
-FIXED: Removed duplicate definition of timer_stopped.
-DONE: Also changed 0 to timer_0 where appropriate.
-FIXED: Fixed: Fake tiles randomly appeared in place of the disappearing sword.
 DONE: Added some contributors and thanks to the Readme.
+DONE: Removed some old unneeded files.
+DONE: Added comments to explain the available options in SDLPoP.ini
+DONE: Add info on the "mod" command line option to doc/Readme.txt
+DONE: Allow opening DAT files from the data/ directory as well; Moved DAT files to data/ to clean up the main folder.
+CHANGE: Folders in the data/ directory no longer have the .DAT extension, so they can coexist with .DAT files.
+FIXED: Removed Dev-C++ note from Linux Makefile.
+FIXED: Use Mix_Music instead of Mix_Chunk to play music files. This reduces loading time. (contributed by @usineur)
+FIXED: Fixed Dávid's name in the header comments.
+
+Game additions, changes, bug fixes:
+CHANGE: Let time just run when quickloading immediately after quicksave
+DONE: Added remembering guard hitpoints (optional fix/enhancement)
+FIXED: Fixed the kid being able to glide sideways through the top sections of walls/tapestries while in freefall.
+FIXED: Fixed the kid dropping through tiles when dropping down from a tapestry.
+FIXED: Fixed the landing animation aborting when landing against a gate or tapestry+floor instead of a wall.
+FIXED: Changed the RGB/BGR hack: check whether SDL2 bug occurs before applying RGB24 workaround.
+FIXED: Fixed crashing from guards on level 14.
+FIXED: Fixed fake tiles randomly appeared in place of the disappearing sword.
 FIXED: Fixed crashing on certain custom DAT files.
 FIXED: Don't crash if some (or all) data files are missing.
 CHANGE: Increased sound buffer size to remove noise.
-DONE: Visual C++ (NMake) support
 CHANGE: Increased sound output settings to CD quality. (That is: 44100 Hz, 16-bit, Stereo.)
+FIXED: Audio: Changed 16-bit to signed. (@vanfanel wrote this is needed on the Raspberry PI.)
 FIXED: Fix joypad/joystick movement
 CHANGE: Same threshold for both joystick axes
-DONE: Removed some old unneeded files.
-FIXED: Audio: Changed 16-bit to signed. (@vanfanel wrote this is needed on the Raspberry PI.)
-FIXED: Fixed bug (and compiler warning) in redraw_at_cur_mob(). (Reported by @petervas.)
 CHANGE: Controller: Remapped Quit to Start (was B).
+FIXED: Fixed bug (and compiler warning) in redraw_at_cur_mob(). (Reported by @petervas.)
 DONE: Added ability to organise mods into their own directories
 DONE: Use a custom configuration file (mod.ini) for each mod
 CHANGE: Change default of use_fixes_and_enhancements to false
-CHANGE: Changed COUNT to sizeof in memset.
-DONE: Added missing color ids, using the color names of the default EGA palette
-CHANGE: Set minimum CMake version required to 2.8
-DONE: Added comments to explain the available options in SDLPoP.ini
-DONE: Added some comments in land().
-FIXED: Added range checks in load_frame().
-FIXED: Added newline at the end of error messages that didn't already have one.
 FIXED: Don't repeat Alt+Enter.
-CHANGE: Renamed `source/` to `src/`. (In the with-folders branch.)
-FIXED: Make NMakefile and unistd_win.h non-executable
-DONE: Add optimization level (O2) to Makefile, silence uninitialized warning
-DONE: Remove CMakeLists.txt in root directory
 FIXED: Alt+Enter should not un-pause the game.
 FIXED: Improved fix for "standing on thin air" bug
 FIXED: Fix new falling bug caused by "glide through wall" fix
 FIXED: Fix unintended sword strike immediately after drawing sword
 FIXED: Fix retreating out of a room without the room actually changing
 FIXED: Fix running jump through tapestry
+DONE: Added test level for jumping through tapestry
 FIXED: Fix guards being pushed into walls
 FIXED: Fix jumping through a wall above a closed gate
-DONE: Added optimization (-O2) to Dev-C++ release project as well.
-DONE: Added test level for jumping through tapestry
 CHANGE: Debug timer: display in top left corner, toggle with T
-FIXED: Add a way to actually enable debug cheats
+FIXED: Added a way to enable debug cheats: use command-line parameter "debug"
 DONE: Allow choosing a levelset from the command line (mod="My Mod Name")
-DONE: Add .editorconfig
-DONE: Slightly different formatting for CusPop options in SDLPoP.ini
 DONE: CusPop option: start upside down
 DONE: CusPop option: start in blind mode (slightly buggy)
 DONE: CusPop option: set level before which the copy protection level appears
 DONE: CusPop option: set up edges of the level
 DONE: CusPop option: enable dungeon WDA in palace environment
 CHANGE: Mod names as separate command line arguments
-DONE: Add info on the "mod" command line option to doc/Readme.txt
-FIXED: Do not accept filenames as valid parameters in check_param()
-CHANGE: Moved source to src/. (That is, merged the with-folders branch into master.)
-DONE: Added maximum path length macro POP_MAX_PATH set to 256
+FIXED: Do not accept filenames as valid command-line parameters in check_param()
 CHANGE: Use a separate Hall of Fame file when playing a custom levelset
 DONE: Allow disabling the time limit completely
 CHANGE: Use a separate QUICKSAVE.SAV / PRINCE.SAV when playing a custom levelset
+CHANGE: Replays get saved to the replays/ directory, have more recognizable names, and are played back in reverse creation order.
+CHANGE: Gameplay options are now stored differently in replays.
+DONE: Allow changing the folder where replays are kept.
+DONE: CusPop option: change the hard-coded color palette
+DONE: CusPop option: change the first level (starting level)
+DONE: CusPop option: skip title sequence
+DONE: CusPop option: set up effect of Shift+L in non-cheat mode
+DONE: CusPop option: set up cutscenes
+FIXED: Alternate fix for drawing bug when gates are stacked on top of each other.
+FIXED: Alternate fix for drawing bug when climbing up to a floot with a big pillar top behind.
+FIXED: Fix chompers not starting when grabbing a ledge.
+DONE: Improved controller support; migrated to SDL_GameController API (reported by @EndeavourAccuracy).
+DONE: Implemented two settings for joystick control: horizontal-only (default; idea and original implementation by @EndeavourAccuracy) and all-directional.
+
+Build changes, source code, refactoring:
+DONE: OSX port upgraded from SDL to SDL2. Mixer library added in makefile and documentation. Tested.
+DONE: Merged both makefiles. Now make is fully portable.
+CHANGE: Updated CMakeLists.txt
+FIXED: Removed duplicate const to avoid warnings in default gcc settings on OSX. Commented an always-true if.
+DONE: Removed unneeded libraries from Dev-C++ projects.
+DONE: Add OSX build configuration for CMake
+FIXED: config: compile with USE_MIXER undefined
+FIXED: Added extern to all variables in data.h.
+FIXED: Removed duplicate definition of timer_stopped.
+DONE: Also changed 0 to timer_0 where appropriate.
+DONE: Visual C++ (NMake) support
+CHANGE: Changed COUNT to sizeof in memset.
+DONE: Added missing color ids, using the color names of the default EGA palette
+CHANGE: Set minimum CMake version required to 2.8
+DONE: Added some comments in land().
+FIXED: Added range checks in load_frame().
+FIXED: Added newline at the end of error messages that didn't already have one.
+FIXED: Make NMakefile and unistd_win.h non-executable
+DONE: Add optimization level (O2) to Makefile, silence uninitialized warning
+DONE: Remove CMakeLists.txt in root directory
+DONE: Added optimization (-O2) to Dev-C++ release project as well.
+DONE: Add .editorconfig
+DONE: Added maximum path length macro POP_MAX_PATH set to 256
 CHANGE: Refactor so that HOF path is obtained from get_hof_path()
+CHANGE: Refactor: removed options_type (replacement: options are stored using SDL_RWops streams).

--- a/doc/ChangeLog.txt
+++ b/doc/ChangeLog.txt
@@ -384,6 +384,7 @@ FIXED: Alternate fix for drawing bug when climbing up to a floot with a big pill
 FIXED: Fix chompers not starting when grabbing a ledge.
 DONE: Improved controller support; migrated to SDL_GameController API (reported by @EndeavourAccuracy).
 DONE: Implemented two settings for joystick control: horizontal-only (default; idea and original implementation by @EndeavourAccuracy) and all-directional.
+FIXED: Reduced flickering when text is drawn.
 
 Build changes, source code, refactoring:
 DONE: OSX port upgraded from SDL to SDL2. Mixer library added in makefile and documentation. Tested.

--- a/doc/Readme.txt
+++ b/doc/Readme.txt
@@ -27,6 +27,7 @@ Contributors:
 * mfn (fixed a small bug when USE_MIXER is undefined)
 * diddledan (Visual C++ (NMake) support)
 * zaps166 (small Makefile fixes)
+* usineur (faster music loading)
 
 Forum board: http://forum.princed.org/viewforum.php?f=126
 GitHub: https://github.com/NagyD/SDLPoP
@@ -108,11 +109,13 @@ Controlling the kid:
 You can also use the numeric keypad.
 
 Gamepad equivalents:
-* arrows = D-Pad/joysticks
-* A = down
-* X = shift
-* Y = up
-* Start = quit
+* D-Pad: arrows
+* Joystick: left/right (for all-directional joystick movement, set joystick_only_horizontal to false in SDLPoP.ini)
+* A: down
+* Y: up
+* X or triggers: shift
+* Start: quit
+* Back: restart level (Ctrl+A)
 
 Controlling the game:
 * Esc: pause game
@@ -218,10 +221,11 @@ Q: How do replays work?
 A:
 Starting from version 1.16, you can capture or view replays in SDLPoP.
 To start recording, press Ctrl+Tab while in game. To stop recording, press Ctrl+Tab again.
-Your replays get saved in the SDLPoP folder as files with a .P1R extension (REPLAY_001.P1R, REPLAY_002.P1R, and so on).
+Your replays get saved in the "replays/" directory as files with a .P1R extension.
+You can change where replays are kept using the setting 'replays_folder' in SDLPoP.ini.
 
 To view a replay, you can press Tab while on the title screen.
-The game then looks for replays with the REPLAY_XXX.P1R pattern and plays those in order (you can cycle by pressing Tab again).
+To cycle to the next replay (in reverse creation order), press Tab again.
 You can also double-click on a replay file (and tell the OS that the file needs to be opened with the SDLPoP executable).
 SDLPoP will then immediately play that replay. Dragging and dropping onto the executable also works.
 

--- a/src/config.h
+++ b/src/config.h
@@ -30,7 +30,7 @@ The authors of this program may be contacted at http://forum.princed.org
 #define POP_MAX_PATH 256
 #define POP_MAX_OPTIONS_SIZE 256
 
-#define WINDOW_TITLE "Prince of Persia (SDLPoP) v1.17 - pre-release"
+#define WINDOW_TITLE "Prince of Persia (SDLPoP) v1.17"
 
 // Enable or disable fading.
 // Fading used to be very buggy, but now it works correctly.

--- a/src/replay.c
+++ b/src/replay.c
@@ -355,6 +355,7 @@ void start_replay() {
 	if (!enable_replay) return;
 	need_start_replay = 0;
 	list_replay_files();
+	if (num_replay_files == 0) return;
 	replaying = 1;
     curr_tick = 0;
     load_replay();
@@ -410,6 +411,8 @@ void save_recorded_replay() {
 				 replays_folder, timestamp, name, current_level, replay_number);
 		++replay_number;
 	} while (access(filename, F_OK) != -1); // check if file already exists
+
+	mkdir(replays_folder); // create the "replays" folder if it does not exist already
 
     replay_fp = fopen(filename, "wb");
     if (replay_fp != NULL) {

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -1119,8 +1119,7 @@ void get_joystick_state(int raw_x, int raw_y, int axis_state[2]) {
 #define DEGREES_TO_RADIANS (M_PI/180.0)
 
 	// check if the X/Y position is within the 'dead zone' of the joystick
-	int reduced_y = raw_y / 2; // y-axis cutoff biased for less sensitivity near the neutral position of the joystick
-	int dist_squared = raw_x*raw_x + reduced_y*reduced_y;
+	int dist_squared = raw_x*raw_x + raw_y*raw_y;
 	if (dist_squared < JOY_THRESHOLD*JOY_THRESHOLD) {
 		axis_state[0] = 0;
 		axis_state[1] = 0;

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -1047,7 +1047,10 @@ const rect_type far *__pascal draw_text(const rect_type far *rect_ptr,int x_alig
 void __pascal far show_text(const rect_type far *rect_ptr,int x_align,int y_align,const char far *text) {
 	// stub
 	//printf("show_text: %s\n",text);
+	int temp = screen_updates_suspended;
+	screen_updates_suspended = 1;
 	draw_text(rect_ptr, x_align, y_align, text, strlen(text));
+	screen_updates_suspended = temp;
 	request_screen_update();
 }
 


### PR DESCRIPTION
* Fixed the issues with replays as reported by @EndeavourAccuracy 
  * Automatically create replays folder if it does not exist already
  * Upon pressing Tab on the title screen, check that there are actually >0 replays present before trying to load the first one
* Changed window title for 1.17
* Controller: use normal Y-axis sensitivity in all-directional mode
  * After playtesting the all-directional controller mode some more, I concluded that reduced Y-sensitivity didn't really help very much... And it is annoying because climbing and jumping becomes less responsive. So I undid this change from commit c7fd07c.
* Updated Changelog
  * Split the entries into a few categories for easier reading (general changes, game additions/changes/fixes, build changes/source code/refactoring)
  * Added the most recent changes
  * Removed some entries that mention the same thing a second time
  * Other small tweaks
* Updated Readme
  * Added thanks to @usineur for contributing
  * Updated gamepad controls documentation
  * Updated replays documentation
* Reduce flickering when text is drawn (prevent an unnecessary screen update in `show_text()`)
* Set `use_fixes_and_enhancements` back to `false`, which I set to true by mistake earlier