### PR TITLE
Slightly tweaked the fix to prevent falling through a wall above a gate

### DIFF
--- a/src/seg005.c
+++ b/src/seg005.c
@@ -78,7 +78,16 @@ void __pascal far do_fall() {
 			// To prevent in_wall() from being called we need to update Char.curr_col here.
 			// (in_wall() only makes things worse, because it tries to 'eject' the kid from the wall the wrong way.
 			// For this reason, the kid can end up behind a closed gate below, like is possible in Level 7)
-			determine_col();
+
+			// The fix is calling determine_col() here.
+
+			// One caveat: the kid can also land on the rightmost edge of a closed gate tile, when doing a running jump
+			// to the left from two floors up. This 'trick' can be used in original PoP, but is 'fixed' by this change.
+			// To still allow this trick to be possible, we can check that we not jumping into a gate tile.
+			// (By the way, strangely enough, in unmodified PoP the trick even works with a tapestry + floor tile...)
+
+			if (get_tile_at_char() != tiles_4_gate)
+				determine_col();
 		}
         #endif
 


### PR DESCRIPTION
It appears that a subtle trick is disabled by the FIX_JUMP_THROUGH_WALL_ABOVE_GATE fix:
Without the fix enabled, you can land on the rightmost edge of a closed gate tile, if you do a running jump from two floors up. Then you take damage and can grab the closed gate.
But the fix makes this impossible. By checking whether the kid may be jumping into a gate tile, we can make the trick possible again.
(By the way, strangely enough, in unmodified PoP the trick even works with a tapestry + floor tile...)

See the pictures below:
![jump_into_closed_gate_testroom](https://cloud.githubusercontent.com/assets/8642739/20464387/cb9a87fc-af46-11e6-90a1-c1313f6dadc8.png)
![jump_into_closed_gate_land](https://cloud.githubusercontent.com/assets/8642739/20464390/d05d95cc-af46-11e6-8c83-24be280f4eea.png)


(It is probably not needed to put this in the changelog, because the original fix is also being added in 1.17)