### PR TITLE
Add SDLPoP splash screen as suggested by @EndeavourAccuracy

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -26,6 +26,9 @@ enable_flash = true
 ; Enable or disable texts.
 enable_text = true
 
+; Display the SDLPoP information screen when the game starts.
+enable_info_screen = true;
+
 ; Start the game in fullscreen mode. (In-game fullscreen toggle: Alt+Enter)
 start_fullscreen = false
 

--- a/doc/ChangeLog.txt
+++ b/doc/ChangeLog.txt
@@ -385,6 +385,7 @@ FIXED: Fix chompers not starting when grabbing a ledge.
 DONE: Improved controller support; migrated to SDL_GameController API (reported by @EndeavourAccuracy).
 DONE: Implemented two settings for joystick control: horizontal-only (default; idea and original implementation by @EndeavourAccuracy) and all-directional.
 FIXED: Reduced flickering when text is drawn.
+DONE: Added info screen shown at startup, with some explanation about SDLPoP.
 
 Build changes, source code, refactoring:
 DONE: OSX port upgraded from SDL to SDL2. Mixer library added in makefile and documentation. Tested.

--- a/src/config.h
+++ b/src/config.h
@@ -30,7 +30,8 @@ The authors of this program may be contacted at http://forum.princed.org
 #define POP_MAX_PATH 256
 #define POP_MAX_OPTIONS_SIZE 256
 
-#define WINDOW_TITLE "Prince of Persia (SDLPoP) v1.17"
+#define SDLPOP_VERSION "1.17"
+#define WINDOW_TITLE "Prince of Persia (SDLPoP) v" SDLPOP_VERSION
 
 // Enable or disable fading.
 // Fading used to be very buggy, but now it works correctly.

--- a/src/data.h
+++ b/src/data.h
@@ -570,6 +570,7 @@ extern int joy_right_stick_states[2];
 extern int joy_hat_states[2]; // horizontal, vertical
 extern int joy_AY_buttons_state;
 extern int joy_X_button_state;
+extern int joy_B_button_state;
 
 extern int screen_updates_suspended;
 
@@ -636,6 +637,7 @@ extern byte enable_mixer INIT(= 1);
 extern byte enable_fade INIT(= 1);
 extern byte enable_flash INIT(= 1);
 extern byte enable_text INIT(= 1);
+extern byte enable_info_screen INIT(= 1);
 extern byte joystick_only_horizontal INIT(= 0);
 extern byte enable_quicksave INIT(= 1);
 extern byte enable_quicksave_penalty INIT(= 1);

--- a/src/options.c
+++ b/src/options.c
@@ -328,10 +328,11 @@ static int global_ini_callback(const char *section, const char *name, const char
         process_boolean("enable_fade", &enable_fade);
         process_boolean("enable_flash", &enable_flash);
         process_boolean("enable_text", &enable_text);
-        process_boolean("start_fullscreen", &start_fullscreen);
-        process_word("pop_window_width", &pop_window_width, NULL);
-        process_word("pop_window_height", &pop_window_height, NULL);
-        process_boolean("use_correct_aspect_ratio", &use_correct_aspect_ratio);
+		process_boolean("enable_info_screen", &enable_info_screen);
+		process_boolean("start_fullscreen", &start_fullscreen);
+		process_word("pop_window_width", &pop_window_width, NULL);
+		process_word("pop_window_height", &pop_window_height, NULL);
+		process_boolean("use_correct_aspect_ratio", &use_correct_aspect_ratio);
         process_boolean("joystick_only_horizontal", &joystick_only_horizontal);
 
         if (strcasecmp(name, "levelset") == 0) {

--- a/src/proto.h
+++ b/src/proto.h
@@ -72,6 +72,7 @@ void __pascal far load_title_images(int bgcolor);
 void __pascal far show_copyprot(int where);
 void __pascal far show_loading();
 void __pascal far show_quotes();
+void show_splash();
 #ifdef USE_QUICKSAVE
 void check_quick_op();
 void restore_room_after_quick_load();

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -125,6 +125,7 @@ void __pascal far init_game_main() {
 	load_sounds(0, 43);
 	load_opt_sounds(43, 56); //added
 	hof_read();
+	show_splash(); // added
 	show_use_fixes_and_enhancements_prompt(); // added
 	start_game();
 }
@@ -1939,4 +1940,53 @@ void __pascal far show_quotes() {
 		start_timer(timer_0,0x384);
 	}
 	need_quotes = 0;
+}
+
+const rect_type splash_text_1_rect = {0, 0, 50, 320};
+const rect_type splash_text_2_rect = {50, 0, 200, 320};
+
+const char* splash_text_1 = "SDLPoP " SDLPOP_VERSION;
+const char* splash_text_2 =
+		"To quick load/save, press F6/F9 in-game.\n"
+		"\n"
+		"To record replays, press Ctrl+Tab in-game.\n"
+		"To view replays, press Tab on the title screen.\n"
+		"\n"
+		"Edit SDLPoP.ini to customize SDLPoP.\n"
+		"Mods also work with SDLPoP.\n"
+		"\n"
+		"For more information, read doc/Readme.txt.\n"
+		"Questions? Visit http://forum.princed.org\n"
+		"\n"
+		"Press any key to continue...";
+
+void show_splash() {
+	if (!enable_info_screen || start_level != 0) return;
+	screen_updates_suspended = 0;
+	current_target_surface = onscreen_surface_;
+	draw_rect(&screen_rect, 0);
+	show_text_with_color(&splash_text_1_rect, 0, 0, splash_text_1, color_15_brightwhite);
+	show_text_with_color(&splash_text_2_rect, 0, -1, splash_text_2, color_7_lightgray);
+
+	int key = 0;
+	do {
+		idle();
+		key = key_test_quit();
+
+		if (joy_hat_states[0] != 0 || joy_X_button_state != 0 || joy_AY_buttons_state != 0 || joy_B_button_state != 0) {
+			joy_hat_states[0] = 0;
+			joy_AY_buttons_state = 0;
+			joy_X_button_state = 0;
+			joy_B_button_state = 0;
+			key_states[SDL_SCANCODE_LSHIFT] = 1; // close the splash screen using the gamepad
+		}
+
+	} while(key == 0 && !(key_states[SDL_SCANCODE_LSHIFT] || key_states[SDL_SCANCODE_RSHIFT]));
+
+	if (key & WITH_CTRL || (enable_quicksave && key == SDL_SCANCODE_F9) || (enable_replay && key == SDL_SCANCODE_TAB)) {
+		extern int last_key_scancode; // defined in seg009.c
+		last_key_scancode = key; // can immediately do Ctrl+L, etc from the splash screen
+	}
+	key_states[SDL_SCANCODE_LSHIFT] = 0; // don't immediately start the game if shift was pressed!
+	key_states[SDL_SCANCODE_RSHIFT] = 0;
 }

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -2591,6 +2591,7 @@ void idle() {
 					case SDL_CONTROLLER_BUTTON_A:          joy_AY_buttons_state = 1;  break; /*** A (down) ***/
 					case SDL_CONTROLLER_BUTTON_Y:          joy_AY_buttons_state = -1; break; /*** Y (up) ***/
 					case SDL_CONTROLLER_BUTTON_X:          joy_X_button_state = 1;    break; /*** X (shift) ***/
+					case SDL_CONTROLLER_BUTTON_B:          joy_B_button_state = 1;    break; /*** B (unused) ***/
 
 					case SDL_CONTROLLER_BUTTON_START:
 						last_key_scancode = SDL_SCANCODE_R | WITH_CTRL; /*** start (restart game) ***/
@@ -2614,6 +2615,7 @@ void idle() {
 					case SDL_CONTROLLER_BUTTON_A:          joy_AY_buttons_state = 0; break; /*** A (down) ***/
 					case SDL_CONTROLLER_BUTTON_Y:          joy_AY_buttons_state = 0; break; /*** Y (up) ***/
 					case SDL_CONTROLLER_BUTTON_X:          joy_X_button_state = 0;   break; /*** X (shift) ***/
+					case SDL_CONTROLLER_BUTTON_B:          joy_B_button_state = 0;   break; /*** B (unused) ***/
 
 					default: break;
 				}


### PR DESCRIPTION
Info screen can be closed with a controller as well. I added a button state for the B button, otherwise that button would be the only button (out of A/B/X/Y) that is unable to close the splash screen, which would be strange...
You can directly use Ctrl+L (etc.), F9, Tab from the info screen without closing it first.
Also added SDLPOP_VERSION macro as suggested by @EndeavourAccuracy.
Updated ChangeLog.txt as well.