### PR TITLE
Various bug fixes

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -176,6 +176,9 @@ fix_jump_through_wall_above_gate = true
 ; If you grab a ledge that is one or more floors down, the chompers on that row will not start.
 fix_chompers_not_starting = true
 
+; As soon as a level door has completely opened, the feather fall effect is interrupted because the sound stops.
+fix_feather_interrupted_by_leveldoor = true
+
 
 
 [CustomGameplay]

--- a/doc/ChangeLog.txt
+++ b/doc/ChangeLog.txt
@@ -386,6 +386,10 @@ DONE: Improved controller support; migrated to SDL_GameController API (reported 
 DONE: Implemented two settings for joystick control: horizontal-only (default; idea and original implementation by @EndeavourAccuracy) and all-directional.
 FIXED: Reduced flickering when text is drawn.
 DONE: Added info screen shown at startup, with some explanation about SDLPoP.
+FIXED: Fixed quickload penalty being applied even after time has stopped (after Jaffar has been killed)
+FIXED: Fixed guards sometimes turning around immediately after quickloading (because is_guard_notice is not set to zero)
+FIXED: Silenced warnings being printed about image 255, after entering an exit door.
+FIXED: Fixed feather fall effect being interrupted by a level door opening.
 
 Build changes, source code, refactoring:
 DONE: OSX port upgraded from SDL to SDL2. Mixer library added in makefile and documentation. Tested.

--- a/doc/mod.ini
+++ b/doc/mod.ini
@@ -128,6 +128,9 @@
 ; If you grab a ledge that is one or more floors down, the chompers on that row will not start.
 ;fix_chompers_not_starting = true
 
+; As soon as a level door has completely opened, the feather fall effect is interrupted because the sound stops.
+;fix_feather_interrupted_by_leveldoor = true
+
 [CustomGameplay]
 ; Starting minutes left. (default = 60)
 ; To disable the time limit completely, set this to -1.

--- a/src/config.h
+++ b/src/config.h
@@ -181,6 +181,9 @@ The authors of this program may be contacted at http://forum.princed.org
 // If you grab a ledge that is one or more floors down, the chompers on that row will not start.
 #define FIX_CHOMPERS_NOT_STARTING
 
+// As soon as a level door has completely opened, the feather fall effect is interrupted because the sound stops.
+#define FIX_FEATHER_INTERRUPTED_BY_LEVELDOOR
+
 
 // Debug features:
 

--- a/src/data.h
+++ b/src/data.h
@@ -672,6 +672,7 @@ extern byte fix_running_jump_through_tapestry INIT(= 1);
 extern byte fix_push_guard_into_wall INIT(= 1);
 extern byte fix_jump_through_wall_above_gate INIT(= 1);
 extern byte fix_chompers_not_starting INIT(= 1);
+extern byte fix_feather_interrupted_by_leveldoor INIT(= 1);
 
 // Custom Gameplay settings
 extern word start_minutes_left INIT(= 60);

--- a/src/options.c
+++ b/src/options.c
@@ -102,6 +102,7 @@ void options_process(SDL_RWops* rw, rw_process_func_type process_func) {
     process(fix_push_guard_into_wall);
     process(fix_jump_through_wall_above_gate);
     process(fix_chompers_not_starting);
+    process(fix_feather_interrupted_by_leveldoor);
     process(start_minutes_left);
     process(start_ticks_left);
     process(start_hitp);
@@ -182,6 +183,7 @@ void disable_fixes_and_enhancements() {
     fix_push_guard_into_wall = 0;
     fix_jump_through_wall_above_gate = 0;
     fix_chompers_not_starting = 0;
+	fix_feather_interrupted_by_leveldoor = 0;
 }
 
 // .ini file parser adapted from https://gist.github.com/OrangeTide/947070
@@ -395,6 +397,7 @@ static int global_ini_callback(const char *section, const char *name, const char
         process_boolean("fix_push_guard_into_wall", &fix_push_guard_into_wall);
         process_boolean("fix_jump_through_wall_above_gate", &fix_jump_through_wall_above_gate);
         process_boolean("fix_chompers_not_starting", &fix_chompers_not_starting);
+        process_boolean("fix_feather_interrupted_by_leveldoor", &fix_feather_interrupted_by_leveldoor);
     }
 
     if (check_ini_section("CustomGameplay")) {

--- a/src/replay.c
+++ b/src/replay.c
@@ -412,7 +412,12 @@ void save_recorded_replay() {
 		++replay_number;
 	} while (access(filename, F_OK) != -1); // check if file already exists
 
-	mkdir(replays_folder); // create the "replays" folder if it does not exist already
+	// create the "replays" folder if it does not exist already
+#if defined WIN32 || _WIN32 || WIN64 || _WIN64
+	mkdir (replays_folder);
+#else
+	mkdir (replays_folder, 0700);
+#endif
 
     replay_fp = fopen(filename, "wb");
     if (replay_fp != NULL) {

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -380,7 +380,10 @@ int quick_load() {
 
 		#ifdef USE_QUICKLOAD_PENALTY
 		// Subtract one minute from the remaining time (if it is above 5 minutes)
-		if (enable_quicksave_penalty) {
+		if (enable_quicksave_penalty &&
+			// don't apply the penalty after time has already stopped!
+			(current_level < 13 || (current_level == 13 && leveldoor_open < 2))
+		) {
 			int ticks_elapsed = 720 * (rem_min - old_rem_min) + (rem_tick - old_rem_tick);
 			// don't restore time at all if the elapsed time is between 0 and 1 minutes
 			if (ticks_elapsed > 0 && ticks_elapsed < 720) {

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -333,6 +333,7 @@ void restore_room_after_quick_load() {
 	load_room_links();
 	//draw_level_first();
 	//gen_palace_wall_colors();
+	is_guard_notice = 0; // prevent guard turning around immediately
 	draw_game_frame(); // for falling
 	//redraw_screen(1); // for room_L
 

--- a/src/seg007.c
+++ b/src/seg007.c
@@ -441,6 +441,9 @@ Possible values of trob_type:
 			++curr_modifier;
 			if (curr_modifier >= 43) {
 				trob.type = -1;
+#ifdef FIX_FEATHER_INTERRUPTED_BY_LEVELDOOR
+				if (!(fix_feather_interrupted_by_leveldoor && is_feather_fall))
+#endif
 				stop_sounds();
 				if (leveldoor_open == 0 || leveldoor_open == 2) {
 					leveldoor_open = 1;

--- a/src/seg008.c
+++ b/src/seg008.c
@@ -722,7 +722,7 @@ image_type* get_image(short chtab_id, int id) {
 		return NULL;
     }
 	if (id < 0 || id >= chtab->n_images) {
-		printf("Tried to use image %d of chtab %d, not in 0..%d\n", id, chtab_id, chtab->n_images-1);
+		if (id != 255) printf("Tried to use image %d of chtab %d, not in 0..%d\n", id, chtab_id, chtab->n_images-1);
 		return NULL;
 	}
 	return chtab->images[id];


### PR DESCRIPTION
Sorry about the so many separate things... I bundled some more bug fixes together, to avoid making pull requests for each separate issue. I hope that's OK.

* Fix error due to missing `mkdir()` argument on Linux
  * This fix was suggested by @EndeavourAccuracy
* Fix quickload penalty being applied even after time has stopped (obviously this should not happen...)
* Fix guard turning around immediately after quickloading
  * To reproduce the bug: in a room where a guard has not yet noticed you and has his back turned towards you, quicksave. Then alert the guard, so that he takes the active stance facing you. Then, still in the same room, quickload; then, the guard will immediately be facing you even though you have not alerted him.
* Silence warning about image 255 e.g. after entering an exit door
  * This happens after entering an exit door, because then the kid's frame is set to zero, and `frame_table_kid[0].image == 255` (and image 255 does not exist).
* Fix feather fall effect being interrupted by the level door opening
  * This bug is noticable in original Level 7, if you trigger the level door while the weightless effect is still active.