### PR TITLE
Enable launching the game using a custom executable (mod.dll)

### DIFF
--- a/doc/ChangeLog.txt
+++ b/doc/ChangeLog.txt
@@ -413,3 +413,4 @@ DONE: Add .editorconfig
 DONE: Added maximum path length macro POP_MAX_PATH set to 256
 CHANGE: Refactor so that HOF path is obtained from get_hof_path()
 CHANGE: Refactor: removed options_type (replacement: options are stored using SDL_RWops streams).
+DONE: Added the 'mod' build target for customized SDLPoP executables in CMakeLists.txt.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 project(SDLPoP)
 
-# Use C++11 when using the C++ compiler
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wall")
 
 if (WIN32)
     # Use the -mwindows compiler flag when compiling with MinGW to hide the console window
@@ -14,10 +13,10 @@ if (WIN32)
     endif (NOT (CMAKE_BUILD_TYPE STREQUAL "Debug"))
 endif(WIN32)
 
-# have CMake output binaries to the directory that contains the source files
+# Have CMake output binaries to the main directory
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${SDLPoP_SOURCE_DIR}/..")
 
-# if SDL_2, SDL2_image and SDL2_mixer are not in the toolchain/build environment, specify /include and /lib paths:
+# If SDL_2, SDL2_image and SDL2_mixer are not in the toolchain/build environment, specify /include and /lib paths:
 
 #set(DIR_SDL2 "C:/SDL2-2.0.3")
 #include_directories(${DIR_SDL2}/include)
@@ -45,11 +44,36 @@ set(SOURCE_FILES
         replay.c
         types.h
         )
-add_executable(prince ${SOURCE_FILES})
 
 if(WIN32)
-    target_link_libraries(prince mingw32 SDL2main SDL2 SDL2.dll SDL2_image SDL2_mixer)
+    set(LIBS mingw32 SDL2main SDL2 SDL2.dll SDL2_image SDL2_mixer)
 else()
-    target_link_libraries(prince SDL2main SDL2 SDL2_image SDL2_mixer m)
+    set(LIBS SDL2main SDL2 SDL2_image SDL2_mixer m dl)
 endif()
 
+# Target: prince executable
+# =========================
+
+add_executable(prince ${SOURCE_FILES})
+target_link_libraries(prince ${LIBS})
+
+# Target: mod executable or dll
+# =============================
+
+# Set to 0 if you want to build a launchable mod.exe instead of a shared library
+set(SHOULD_BUILD_MOD_AS_DLL 1)
+
+# List any additional custom source files here:
+set(MOD_SOURCE_FILES )
+
+if (SHOULD_BUILD_MOD_AS_DLL)
+    add_library(mod SHARED ${SOURCE_FILES} ${MOD_SOURCE_FILES})
+    set_target_properties(mod PROPERTIES PREFIX "") # prevent the dll being named "libmod.dll"
+else()
+    add_executable(mod ${SOURCE_FILES} ${MOD_SOURCE_FILES})
+endif()
+
+# List additional preprocessor definitions here:
+target_compile_definitions(mod PUBLIC IS_SDLPOP_MOD_EXE )
+
+target_link_libraries(mod ${LIBS})

--- a/src/main.c
+++ b/src/main.c
@@ -28,3 +28,17 @@ int main(int argc, char *argv[])
 	return 0;
 }
 
+
+#ifdef IS_SDLPOP_MOD_EXE
+
+#ifdef _WIN32
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+EXPORT __stdcall int mod_main(int argc, char *argv[]) {
+	main(argc, argv);
+	return 0;
+}
+#endif //IS_SDLPOP_MOD_EXE


### PR DESCRIPTION
This idea was briefly discussed here (@EndeavourAccuracy):
http://forum.princed.org/viewtopic.php?f=126&t=3512&start=510#p19916
http://forum.princed.org/viewtopic.php?f=126&t=3512&start=510#p19918

This adds a way to let prince.exe act as a 'launcher' for SDLPoP mods.

The file `mod.dll` should be present in the mod folder (or, on Linux, `mod.so`).

I added configurations in CMakeLists.txt to help in building custom mod executables (use the target `mod` to build the mod). The macro `IS_SDLPOP_MOD_EXE` should be defined, only when building the mod. The `mod` target can be built either as a normal executable (easier to launch and test) or as a dll, depending on the value of `SHOULD_BUILD_MOD_AS_DLL`.

With the mod dll in place in the mod folder, you can launch the mod normally, through the command `prince mod <mod_name>` or by using the levelset option in SDLPoP.ini.

I tested it on Windows; I added Linux-specific code as well, but I haven't verified whether it works on Linux as well. Probably this needs some testing...

I restructured CMakeLists.txt a bit as well.
I haven't yet modified the Makefile or the other project files, I am still unsure how to do that...

I did not notice any performance hits when loading a custom mod dll vs launching the custom exe directly. The only difference I could find is that prince.exe uses a few hundred kilobytes more memory.