### PR TITLE
Add CLion-generated build directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ Makefile.win
 # CLion
 .idea/
 src/.idea/
+src/cmake-build*/
+build/


### PR DESCRIPTION
Since version 2016.3, CLion outputs its CMake cache files into the project folder by default (they appear as` src/cmake-build-debug/`, for instance). This adds lots of untracked files which should be ignored by `.gitignore`. 

I then changed that CMake output folder in CLion to `build/` because that seemed to make more sense to me. But then that folder should be ignored as well.