### PR TITLE
Replay: Add a unique identifier / class number for the replay format

### DIFF
--- a/src/replay.c
+++ b/src/replay.c
@@ -255,6 +255,7 @@ void check_if_opening_replay_file() {
 				int ok = read_replay_header(&header, replay_fp, error_message);
 				if (!ok) {
 					printf("Error opening replay file: %s\n", error_message);
+					return;
 				}
 				if (header.uses_custom_levelset) {
 					strncpy(replay_levelset_name, header.levelset_name, sizeof(replay_levelset_name)); // use the replays's levelset


### PR DESCRIPTION
This adds a way to tell apart different implementations/forks of SDLPoP in the replay format. If someone forks SDLPoP and modifies the format and/or version numbers of the replay format, there would be compatibility issues between the different forks. Ideally, the game should be able to recognize that a replay is "foreign" and not attempt to play it.

Also updated the outdated comments in `read_replay_header()`. And refactored away the `replay_header_type.magic` field because it is only used in `read_replay_header()`.