### PR TITLE
Replay: better prevent crashes when loading replay files

### DIFF
--- a/src/proto.h
+++ b/src/proto.h
@@ -629,7 +629,7 @@ void start_replay();
 void do_replay_move();
 void save_recorded_replay();
 void replay_cycle();
-void load_replay();
+int load_replay();
 void key_press_while_recording(int* key_ptr);
 void key_press_while_replaying(int* key_ptr);
 #endif


### PR DESCRIPTION
I think these may have been the critical bugs:
* Used the wrong pointer on line 108
* Didn't properly close the replay file after opening a replay file directly had failed (line 257)
* If something went wrong in load_replay() it could not gracefully recover (now it returns either 0 or 1 so the caller can decide how to fail)