### PR TITLE
Add icon.rc for setting the icon in CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SOURCE_FILES
         options.c
         replay.c
         types.h
+        icon.rc
         )
 add_executable(prince ${SOURCE_FILES})
 

--- a/src/icon.rc
+++ b/src/icon.rc
@@ -1,0 +1,1 @@
+IDI_ICON1   ICON  DISCARDABLE  "icon.ico"


### PR DESCRIPTION
For building with CLion on Windows (on my own system at least), this correctly sets the icon on prince.exe.