### PR TITLE
Add haptic feedback for controllers with a rumble motor

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -42,6 +42,9 @@ pop_window_height = default
 ; NB. Works best using a high resolution.
 use_correct_aspect_ratio = false
 
+; If using a controller with a rumble motor, provide haptic feedback when the kid is hurt.
+enable_controller_rumble = true
+
 ; When using a controller, only use the joysticks for horizontal movement (instead of all-directional movement).
 ; This could make the game easier to control, depending on your preference and depending on which controller you have.
 joystick_only_horizontal = true

--- a/src/data.h
+++ b/src/data.h
@@ -571,6 +571,7 @@ extern int joy_hat_states[2]; // horizontal, vertical
 extern int joy_AY_buttons_state;
 extern int joy_X_button_state;
 extern int joy_B_button_state;
+extern SDL_Haptic* sdl_haptic;
 
 extern int screen_updates_suspended;
 
@@ -639,6 +640,7 @@ extern byte enable_fade INIT(= 1);
 extern byte enable_flash INIT(= 1);
 extern byte enable_text INIT(= 1);
 extern byte enable_info_screen INIT(= 1);
+extern byte enable_controller_rumble INIT(= 0);
 extern byte joystick_only_horizontal INIT(= 0);
 extern byte enable_quicksave INIT(= 1);
 extern byte enable_quicksave_penalty INIT(= 1);

--- a/src/options.c
+++ b/src/options.c
@@ -206,6 +206,7 @@ static int global_ini_callback(const char *section, const char *name, const char
 		process_word("pop_window_width", &pop_window_width, NULL);
 		process_word("pop_window_height", &pop_window_height, NULL);
 		process_boolean("use_correct_aspect_ratio", &use_correct_aspect_ratio);
+        process_boolean("enable_controller_rumble", &enable_controller_rumble);
         process_boolean("joystick_only_horizontal", &joystick_only_horizontal);
 
         if (strcasecmp(name, "levelset") == 0) {

--- a/src/seg003.c
+++ b/src/seg003.c
@@ -647,6 +647,9 @@ int __pascal far flash_if_hurt() {
 		do_flash_no_delay(flash_color); // don't add delay to the flash
 		return 1;
 	} else if (hitp_delta < 0) {
+		if (is_joyst_mode && enable_controller_rumble && sdl_haptic != NULL) {
+			SDL_HapticRumblePlay(sdl_haptic, 1.0, 100); // rumble at full strength for 100 milliseconds
+		}
 		do_flash_no_delay(color_12_brightred); // red
 		return 1;
 	}

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -613,6 +613,13 @@ int __pascal far set_joy_mode() {
 			is_joyst_mode = 1;
 		}
 	}
+	if (enable_controller_rumble && is_joyst_mode) {
+		sdl_haptic = SDL_HapticOpen(0);
+		SDL_HapticRumbleInit(sdl_haptic); // initialize the device for simple rumble
+	} else {
+		sdl_haptic = NULL;
+	}
+
 	is_keyboard_mode = !is_joyst_mode;
 	return is_joyst_mode;
 }
@@ -1920,7 +1927,8 @@ int __pascal far check_sound_playing() {
 
 // seg009:38ED
 void __pascal far set_gr_mode(byte grmode) {
-	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_NOPARACHUTE | SDL_INIT_GAMECONTROLLER ) != 0) {
+	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_NOPARACHUTE |
+				 SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC ) != 0) {
 		sdlperror("SDL_Init");
 		quit(1);
 	}


### PR DESCRIPTION
When in joystick mode, adds a slight rumble effect when the kid gets hurt. 
Tested using an Xbox 360 controller.

Forum topic:
http://forum.princed.org/viewtopic.php?f=126&t=3972