### PR TITLE
Movement fixes

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -187,6 +187,9 @@ The authors of this program may be contacted at http://forum.princed.org
 // Guards will often not reappear in another room if they have been pushed (partly or entirely) offscreen.
 #define FIX_OFFSCREEN_GUARDS_DISAPPEARING
 
+// Controls do not get released properly when putting the sword away, leading to unintended movement.
+#define FIX_MOVE_AFTER_SHEATHE
+
 
 // Debug features:
 

--- a/src/data.h
+++ b/src/data.h
@@ -677,6 +677,7 @@ extern byte fix_jump_through_wall_above_gate INIT(= 1);
 extern byte fix_chompers_not_starting INIT(= 1);
 extern byte fix_feather_interrupted_by_leveldoor INIT(= 1);
 extern byte fix_offscreen_guards_disappearing INIT(= 1);
+extern byte fix_move_after_sheathe INIT(= 1);
 
 // Custom Gameplay settings
 extern word start_minutes_left INIT(= 60);

--- a/src/options.c
+++ b/src/options.c
@@ -55,6 +55,7 @@ void disable_fixes_and_enhancements() {
     fix_chompers_not_starting = 0;
 	fix_feather_interrupted_by_leveldoor = 0;
 	fix_offscreen_guards_disappearing = 0;
+	fix_move_after_sheathe = 0;
 }
 
 // .ini file parser adapted from https://gist.github.com/OrangeTide/947070
@@ -274,6 +275,7 @@ static int global_ini_callback(const char *section, const char *name, const char
         process_boolean("fix_chompers_not_starting", &fix_chompers_not_starting);
         process_boolean("fix_feather_interrupted_by_leveldoor", &fix_feather_interrupted_by_leveldoor);
         process_boolean("fix_offscreen_guards_disappearing", &fix_offscreen_guards_disappearing);
+        process_boolean("fix_move_after_sheathe", &fix_move_after_sheathe);
     }
 
     if (check_ini_section("CustomGameplay")) {

--- a/src/replay.c
+++ b/src/replay.c
@@ -329,6 +329,7 @@ void options_process_fixes(SDL_RWops* rw, rw_process_func_type process_func) {
 	process(fix_chompers_not_starting);
 	process(fix_feather_interrupted_by_leveldoor);
 	process(fix_offscreen_guards_disappearing);
+	process(fix_move_after_sheathe);
 }
 
 void options_process_custom_general(SDL_RWops* rw, rw_process_func_type process_func) {

--- a/src/seg005.c
+++ b/src/seg005.c
@@ -45,6 +45,7 @@ void __pascal far do_fall() {
 		#ifdef FIX_GLIDE_THROUGH_WALL
         if (fix_glide_through_wall) {
 			// Fix for the kid falling through walls after turning around while running (especially when weightless)
+			determine_col();
 			get_tile_at_char();
 			if (curr_tile2 == tiles_20_wall ||
 					((curr_tile2 == tiles_12_doortop || curr_tile2 == tiles_7_doortop_with_floor) &&

--- a/src/seg005.c
+++ b/src/seg005.c
@@ -275,6 +275,14 @@ void __pascal far control() {
 		if (fix_move_after_drink && char_frame >= frame_191_drink && char_frame <= frame_205_drink)
 			release_arrows();
 		#endif
+
+		#ifdef FIX_MOVE_AFTER_SHEATHE
+		if (fix_move_after_sheathe &&
+				Char.curr_seq >= seqtbl_offsets[seq_92_put_sword_away] &&
+				Char.curr_seq < seqtbl_offsets[seq_93_put_sword_away_fast]
+		)
+			release_arrows();
+		#endif
 	}
 }
 


### PR DESCRIPTION
_Fix rare glitch with the "fix glide through wall" bug fix_
On rare occasions, if you run off a ledge with Shift pressed, you may get pushed backwards into the wall, if the fix_glide_through_wall fix is active.
The cause is:
in check_grab(), load_fram_det_col() is called while Char.x has been shifted back by 8. This also sets Char.curr_col. However, determine_col() is not called again! The consequence is that Char.curr_col may be wrong (i.e. one tile too far back).
So what happens in this case is that the kid is pushed back, because the game thinks the kid is inside a wall tile instead of just behind one.

_Fix movement after putting the sword away_
Controls do not get released properly when putting the sword away, leading to unintended movement. For example, if you press forward/down during the sheathing sequence, and then release the controls before the animation ends, the kid will still move even if you did not want to.