### PR TITLE
Replay functionality tweaks

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -625,6 +625,9 @@ extern byte need_start_replay INIT(= 0);
 extern byte need_replay_cycle INIT(= 0);
 extern char replays_folder[POP_MAX_PATH] INIT(= "replays");
 extern byte special_move;
+extern dword saved_random_seed;
+extern dword preserved_seed;
+extern sbyte keep_last_seed;
 #endif // USE_REPLAY
 
 extern byte start_fullscreen INIT(= 0);

--- a/src/proto.h
+++ b/src/proto.h
@@ -626,6 +626,7 @@ void start_recording();
 void add_replay_move();
 void stop_recording();
 void start_replay();
+void stop_replay_and_restart_game();
 void do_replay_move();
 void save_recorded_replay();
 void replay_cycle();

--- a/src/replay.c
+++ b/src/replay.c
@@ -577,15 +577,19 @@ void start_replay() {
     apply_replay_options();
 }
 
+void stop_replay_and_restart_game() {
+	replaying = 0;
+	restore_normal_options();
+	start_game();
+}
+
 void do_replay_move() {
     if (curr_tick == 0) {
         random_seed = saved_random_seed;
         seed_was_init = 1;
     }
     if (curr_tick == num_replay_ticks) { // replay is finished
-        replaying = 0;
-		restore_normal_options();
-        start_game();
+        stop_replay_and_restart_game();
 		return;
     }
 

--- a/src/replay.c
+++ b/src/replay.c
@@ -226,16 +226,19 @@ byte open_replay_file(const char *filename) {
 void change_working_dir_to_sdlpop_root() {
 	char* exe_path = g_argv[0];
 	// strip away everything after the last slash or backslash in the path
-	size_t len;
-	for (len = strlen(exe_path); len >= 0; --len) {
+	int len;
+	for (len = strlen(exe_path); len > 0; --len) {
 		if (exe_path[len] == '\\' || exe_path[len] == '/') {
 			break;
 		}
 	}
-	char exe_dir[POP_MAX_PATH];
-	strncpy(exe_dir, exe_path, len);
-	exe_dir[len] = '\0';
-	chdir(exe_dir);
+	if (len > 0) {
+		char exe_dir[POP_MAX_PATH];
+		strncpy(exe_dir, exe_path, len);
+		exe_dir[len] = '\0';
+		chdir(exe_dir);
+	}
+
 };
 
 // Called in pop_main(); check whether a replay file is being opened directly (double-clicked, dragged onto .exe, etc.)

--- a/src/replay.c
+++ b/src/replay.c
@@ -251,10 +251,15 @@ void check_if_opening_replay_file() {
 				// We should read the header in advance so we know the levelset name
 				// then the game can immediately load the correct resources
 				replay_header_type header = {0};
-				char error_message[REPLAY_HEADER_ERROR_MESSAGE_MAX];
-				int ok = read_replay_header(&header, replay_fp, error_message);
+				char header_error_message[REPLAY_HEADER_ERROR_MESSAGE_MAX];
+				int ok = read_replay_header(&header, replay_fp, header_error_message);
 				if (!ok) {
-					printf("Error opening replay file: %s\n", error_message);
+					char error_message[REPLAY_HEADER_ERROR_MESSAGE_MAX];
+					snprintf(error_message, REPLAY_HEADER_ERROR_MESSAGE_MAX,
+							 "Error opening replay file: %s\n",
+							 header_error_message);
+					fprintf(stderr, error_message);
+					SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "SDLPoP", error_message, NULL);
 					fclose(replay_fp);
 					replay_fp = NULL;
 					replay_file_open = 0;

--- a/src/replay.c
+++ b/src/replay.c
@@ -51,7 +51,6 @@ typedef union replay_move_type {
 } replay_move_type;
 
 dword curr_tick = 0;
-dword saved_random_seed;
 
 FILE* replay_fp = NULL;
 byte replay_file_open = 0;
@@ -592,26 +591,27 @@ void do_replay_move() {
         stop_replay_and_restart_game();
 		return;
     }
+	if (current_level == next_level) {
+		replay_move_type curr_move;
+		curr_move.bits = moves[curr_tick];
 
-    replay_move_type curr_move;
-    curr_move.bits = moves[curr_tick];
+		control_x = curr_move.x;
+		control_y = curr_move.y;
+		control_shift = (curr_move.shift) ? -1 : 0;
 
-    control_x = curr_move.x;
-    control_y = curr_move.y;
-    control_shift = (curr_move.shift) ? -1 : 0;
-
-    if (curr_move.special == MOVE_RESTART_LEVEL) { // restart level
-        stop_sounds();
-        is_restart_level = 1;
-    } else if (curr_move.special == MOVE_EFFECT_END) {
-		stop_sounds();
-		need_level1_music = 0;
-		is_feather_fall = 0;
-	}
+		if (curr_move.special == MOVE_RESTART_LEVEL) { // restart level
+			stop_sounds();
+			is_restart_level = 1;
+		} else if (curr_move.special == MOVE_EFFECT_END) {
+			stop_sounds();
+			need_level1_music = 0;
+			is_feather_fall = 0;
+		}
 
 //    if (curr_tick > 5 ) printf("rem_tick: %d\t curr_tick: %d\tlast 5 moves: %d, %d, %d, %d, %d\n", rem_tick, curr_tick,
 //                               moves[curr_tick-4], moves[curr_tick-3], moves[curr_tick-2], moves[curr_tick-1], moves[curr_tick]);
-    ++curr_tick;
+		++curr_tick;
+	}
 }
 
 const char* original_levels_name = "Prince of Persia";

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -601,6 +601,12 @@ int __pascal far process_key() {
 		break;
 		case SDL_SCANCODE_F9:
 		case SDL_SCANCODE_F9 | WITH_SHIFT:
+#ifdef USE_REPLAY
+			if (recording) {
+				answer_text = "NO QUICKLOAD"; // quickloading would mess up the replay!
+				need_show_text = 1;
+			} else
+#endif
 			need_quick_load = 1;
 		break;
 #ifdef USE_REPLAY

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -1113,6 +1113,10 @@ void __pascal far check_the_end() {
 		drawn_room = next_room;
 		load_room_links();
 		if (current_level == 14 && drawn_room == 5) {
+#ifdef USE_REPLAY
+			if (recording) stop_recording();
+			if (replaying) stop_replay_and_restart_game();
+#endif
 			// Special event: end of game
 			end_sequence();
 		}

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -475,7 +475,10 @@ int __pascal far process_key() {
 			if (key == SDL_SCANCODE_TAB || need_start_replay) {
 				start_replay();
 			}
-			else
+			else if (key == (SDL_SCANCODE_TAB | WITH_CTRL)) {
+				start_level = first_level;
+				start_recording();
+			} else
 			#endif
 			if (key == (SDL_SCANCODE_L | WITH_CTRL)) { // ctrl-L
 				if (!load_game()) return 0;

--- a/src/seg006.c
+++ b/src/seg006.c
@@ -614,6 +614,10 @@ void __pascal far play_seq() {
 						play_sound(sound_18_drink); // drink
 						break;
 					case SND_LEVEL: // level
+#ifdef USE_REPLAY
+						if (recording || replaying) break; // don't do end level music in replays
+#endif
+
 						if (is_sound_on) {
 							if (current_level == 4) {
 								play_sound(sound_32_shadow_music); // end level with shadow (level 4)

--- a/src/seg006.c
+++ b/src/seg006.c
@@ -630,6 +630,12 @@ void __pascal far play_seq() {
 				break;
 			case SEQ_END_LEVEL: // end level
 				++next_level;
+#ifdef USE_REPLAY
+				// Preserve the seed in this frame, to ensure reproducibility of the replay in the next level,
+				// regardless of how long the sound is still playing *after* this frame.
+				// Animations (e.g. torch) can change the seed!
+				keep_last_seed = 1;
+#endif
 				break;
 			case SEQ_GET_ITEM: // get item
 				if (*(SEQTBL_0 + Char.curr_seq++) == 1) {


### PR DESCRIPTION
_Show error message in a dialog box if replay loading failed_
To make it more obvious what went wrong if you double-click a replay file, we can use SDL_ShowSimpleMessageBox to display the error message using a system dialog. (Should be useful, because not everyone would always look at the console output I think...)

_Fix possible crash due to incorrect parsing of the working dir_
I messed up the original code in such a way that the program might read beyond the bounds of the first command-line argument. (fixed)

_Stop the replay upon reaching the Princess room_
Mentioned by @EndeavourAccuracy in this post:
http://forum.princed.org/viewtopic.php?f=126&p=20574#p20561
Also, disabled the end sequence when replaying (restart to title screen instead).

_Don't play end level music while recording or replaying_
The end level music causes problems, because the next level is loaded *exactly* when the music stops. We can avoid this problem by simply not playing the music in replays (both while recording, and while replaying). This also improves the pace of replays -- waiting time between levels is reduced
This should make replays fully reproducible across multiple consecutive levels.

_Don't allow quickloading while recording a replay_
Obviously, quickloading would mess up a recording, because the quickload is not captured into the replay.

Edit:
Added: Start recording immediately if Ctrl+Tab pressed on the title screen.