### PR TITLE
Add save dialog for replays

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -394,6 +394,8 @@ extern byte redraw_frames_fore[30];
 extern byte tile_object_redraw[30];
 // data:4C64
 extern byte redraw_frames_above[10];
+// data:4CE2
+extern word need_full_redraw;
 // data:588E
 extern short n_curr_objs;
 // data:5BAC

--- a/src/proto.h
+++ b/src/proto.h
@@ -628,7 +628,7 @@ void stop_recording();
 void start_replay();
 void stop_replay_and_restart_game();
 void do_replay_move();
-void save_recorded_replay();
+int save_recorded_replay();
 void replay_cycle();
 int load_replay();
 void key_press_while_recording(int* key_ptr);

--- a/src/proto.h
+++ b/src/proto.h
@@ -626,6 +626,7 @@ void start_recording();
 void add_replay_move();
 void stop_recording();
 void start_replay();
+void stop_replay_and_restart_game();
 void do_replay_move();
 void save_recorded_replay();
 void replay_cycle();

--- a/src/replay.c
+++ b/src/replay.c
@@ -577,15 +577,19 @@ void start_replay() {
     apply_replay_options();
 }
 
+void stop_replay_and_restart_game() {
+	replaying = 0;
+	restore_normal_options();
+	start_game();
+}
+
 void do_replay_move() {
     if (curr_tick == 0) {
         random_seed = saved_random_seed;
         seed_was_init = 1;
     }
     if (curr_tick == num_replay_ticks) { // replay is finished
-        replaying = 0;
-		restore_normal_options();
-        start_game();
+        stop_replay_and_restart_game();
 		return;
     }
 

--- a/src/replay.c
+++ b/src/replay.c
@@ -226,16 +226,19 @@ byte open_replay_file(const char *filename) {
 void change_working_dir_to_sdlpop_root() {
 	char* exe_path = g_argv[0];
 	// strip away everything after the last slash or backslash in the path
-	size_t len;
-	for (len = strlen(exe_path); len >= 0; --len) {
+	int len;
+	for (len = strlen(exe_path); len > 0; --len) {
 		if (exe_path[len] == '\\' || exe_path[len] == '/') {
 			break;
 		}
 	}
-	char exe_dir[POP_MAX_PATH];
-	strncpy(exe_dir, exe_path, len);
-	exe_dir[len] = '\0';
-	chdir(exe_dir);
+	if (len > 0) {
+		char exe_dir[POP_MAX_PATH];
+		strncpy(exe_dir, exe_path, len);
+		exe_dir[len] = '\0';
+		chdir(exe_dir);
+	}
+
 };
 
 // Called in pop_main(); check whether a replay file is being opened directly (double-clicked, dragged onto .exe, etc.)

--- a/src/replay.c
+++ b/src/replay.c
@@ -251,10 +251,15 @@ void check_if_opening_replay_file() {
 				// We should read the header in advance so we know the levelset name
 				// then the game can immediately load the correct resources
 				replay_header_type header = {0};
-				char error_message[REPLAY_HEADER_ERROR_MESSAGE_MAX];
-				int ok = read_replay_header(&header, replay_fp, error_message);
+				char header_error_message[REPLAY_HEADER_ERROR_MESSAGE_MAX];
+				int ok = read_replay_header(&header, replay_fp, header_error_message);
 				if (!ok) {
-					printf("Error opening replay file: %s\n", error_message);
+					char error_message[REPLAY_HEADER_ERROR_MESSAGE_MAX];
+					snprintf(error_message, REPLAY_HEADER_ERROR_MESSAGE_MAX,
+							 "Error opening replay file: %s\n",
+							 header_error_message);
+					fprintf(stderr, error_message);
+					SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "SDLPoP", error_message, NULL);
 					fclose(replay_fp);
 					replay_fp = NULL;
 					replay_file_open = 0;

--- a/src/replay.c
+++ b/src/replay.c
@@ -623,12 +623,11 @@ int save_recorded_replay() {
 	short bgcolor = color_8_darkgray;
 	short color = color_15_brightwhite;
 	current_target_surface = onscreen_surface_;
+	screen_updates_suspended = 1;
 	method_1_blit_rect(offscreen_surface, onscreen_surface_, &copyprot_dialog->peel_rect, &copyprot_dialog->peel_rect, 0);
 	draw_dialog_frame(copyprot_dialog);
 	shrink2_rect(&rect, &copyprot_dialog->text_rect, 2, 1);
 	show_text_with_color(&rect, 0, 0, "Save replay\nenter the filename...\n\n", color_15_brightwhite);
-	screen_updates_suspended = 0;
-	request_screen_update();
 	clear_kbd_buf();
 
 	rect_type text_rect;
@@ -637,6 +636,7 @@ int save_recorded_replay() {
 	//peel_type* peel = read_peel_from_screen(&input_rect);
 	draw_rect(&text_rect, bgcolor);
 	current_target_surface = onscreen_surface_;
+	screen_updates_suspended = 0;
 	need_full_redraw = 1; // lazy: instead of neatly restoring the dialog peel, just redraw the whole screen
 
 	char input_filename[POP_MAX_PATH] = "";

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -29,8 +29,6 @@ word cheats_enabled = 0;
 // data:461E
 dat_type * dathandle;
 
-// data:4CE2
-word need_full_redraw;
 // data:4C08
 word need_redraw_because_flipped;
 

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -601,6 +601,12 @@ int __pascal far process_key() {
 		break;
 		case SDL_SCANCODE_F9:
 		case SDL_SCANCODE_F9 | WITH_SHIFT:
+#ifdef USE_REPLAY
+			if (recording) {
+				answer_text = "NO QUICKLOAD"; // quickloading would mess up the replay!
+				need_show_text = 1;
+			} else
+#endif
 			need_quick_load = 1;
 		break;
 #ifdef USE_REPLAY

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -1113,6 +1113,10 @@ void __pascal far check_the_end() {
 		drawn_room = next_room;
 		load_room_links();
 		if (current_level == 14 && drawn_room == 5) {
+#ifdef USE_REPLAY
+			if (recording) stop_recording();
+			if (replaying) stop_replay_and_restart_game();
+#endif
 			// Special event: end of game
 			end_sequence();
 		}

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -434,6 +434,11 @@ void check_quick_op() {
 		text_time_remaining = 24;
 	}
 	if (need_quick_load) {
+#ifdef USE_REPLAY
+		if (recording) {
+			stop_recording(); // quickloading would mess up the replay!
+		}
+#endif
 		if (quick_load()) {
 			display_text_bottom("QUICKLOAD");
 		} else {
@@ -599,12 +604,6 @@ int __pascal far process_key() {
 		break;
 		case SDL_SCANCODE_F9:
 		case SDL_SCANCODE_F9 | WITH_SHIFT:
-#ifdef USE_REPLAY
-			if (recording) {
-				answer_text = "NO QUICKLOAD"; // quickloading would mess up the replay!
-				need_show_text = 1;
-			} else
-#endif
 			need_quick_load = 1;
 		break;
 #ifdef USE_REPLAY

--- a/src/seg006.c
+++ b/src/seg006.c
@@ -614,6 +614,10 @@ void __pascal far play_seq() {
 						play_sound(sound_18_drink); // drink
 						break;
 					case SND_LEVEL: // level
+#ifdef USE_REPLAY
+						if (recording || replaying) break; // don't do end level music in replays
+#endif
+
 						if (is_sound_on) {
 							if (current_level == 4) {
 								play_sound(sound_32_shadow_music); // end level with shadow (level 4)

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -1110,7 +1110,7 @@ int __pascal far showmessage(char far *text,int arg_4,void far *arg_0) {
 	} while(key == 0);
 	//restore_dialog_peel_2(copyprot_dialog->peel);
 	//current_target_surface = old_target;
-	redraw_screen(0); // lazy: instead of neatly restoring only the relevant part, just redraw the whole screen
+	need_full_redraw = 1; // lazy: instead of neatly restoring only the relevant part, just redraw the whole screen
 	return key;
 }
 


### PR DESCRIPTION
Follow-up to #120 

After recording, display a dialog box to ask for the replay filename. (This replaces the automatically generated replay filenames)
Replayed can also be discarded by pressing Escape. (That closes the dialog box without saving the replay.)

![save_replay](https://cloud.githubusercontent.com/assets/8642739/22183462/51f44320-e0bf-11e6-987c-c5d7da433515.png)
