### PR TITLE
Skipping through replays / validating replays from the command-line

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -625,6 +625,9 @@ extern byte need_start_replay INIT(= 0);
 extern byte need_replay_cycle INIT(= 0);
 extern char replays_folder[POP_MAX_PATH] INIT(= "replays");
 extern byte special_move;
+extern dword saved_random_seed;
+extern dword preserved_seed;
+extern sbyte keep_last_seed;
 #endif // USE_REPLAY
 
 extern byte start_fullscreen INIT(= 0);

--- a/src/data.h
+++ b/src/data.h
@@ -628,6 +628,8 @@ extern byte special_move;
 extern dword saved_random_seed;
 extern dword preserved_seed;
 extern sbyte keep_last_seed;
+extern byte skipping_replay;
+extern byte replay_seek_target;
 #endif // USE_REPLAY
 
 extern byte start_fullscreen INIT(= 0);

--- a/src/data.h
+++ b/src/data.h
@@ -630,6 +630,7 @@ extern dword preserved_seed;
 extern sbyte keep_last_seed;
 extern byte skipping_replay;
 extern byte replay_seek_target;
+extern byte is_validate_mode;
 #endif // USE_REPLAY
 
 extern byte start_fullscreen INIT(= 0);

--- a/src/proto.h
+++ b/src/proto.h
@@ -626,6 +626,7 @@ void start_recording();
 void add_replay_move();
 void stop_recording();
 void start_replay();
+void stop_replay_and_restart_game();
 void do_replay_move();
 void save_recorded_replay();
 void replay_cycle();

--- a/src/proto.h
+++ b/src/proto.h
@@ -618,7 +618,7 @@ void show_use_fixes_and_enhancements_prompt();
 
 // REPLAY.C
 #ifdef USE_REPLAY
-void check_if_opening_replay_file();
+void start_with_replay_file(const char *filename);
 void init_record_replay();
 void replay_restore_level();
 int restore_savestate_from_buffer();
@@ -626,7 +626,7 @@ void start_recording();
 void add_replay_move();
 void stop_recording();
 void start_replay();
-void stop_replay_and_restart_game();
+void end_replay();
 void do_replay_move();
 void save_recorded_replay();
 void replay_cycle();

--- a/src/replay.c
+++ b/src/replay.c
@@ -578,6 +578,7 @@ void start_replay() {
 
 void stop_replay_and_restart_game() {
 	replaying = 0;
+	skipping_replay = 0;
 	restore_normal_options();
 	start_game();
 }
@@ -694,6 +695,7 @@ byte open_next_replay_file() {
 
 void replay_cycle() {
     need_replay_cycle = 0;
+	skipping_replay = 0;
     stop_sounds();
     if (current_replay_number == -1 /* opened .P1R file directly, so cycling is disabled */ ||
 			!open_next_replay_file() ||
@@ -802,6 +804,14 @@ void key_press_while_replaying(int* key_ptr) {
             need_replay_cycle = 1;
 			restore_normal_options();
             break;
+		case SDL_SCANCODE_F:                    // skip forward to next room
+			skipping_replay = 1;
+			replay_seek_target = replay_seek_0_next_room;
+			break;
+		case SDL_SCANCODE_F | WITH_SHIFT:       // skip forward to start of next level
+			skipping_replay = 1;
+			replay_seek_target = replay_seek_1_next_level;
+			break;
     }
 }
 

--- a/src/replay.c
+++ b/src/replay.c
@@ -577,15 +577,19 @@ void start_replay() {
     apply_replay_options();
 }
 
+void stop_replay_and_restart_game() {
+	replaying = 0;
+	restore_normal_options();
+	start_game();
+}
+
 void do_replay_move() {
     if (curr_tick == 0) {
         random_seed = saved_random_seed;
         seed_was_init = 1;
     }
     if (curr_tick == num_replay_ticks) { // replay is finished
-        replaying = 0;
-		restore_normal_options();
-        start_game();
+        stop_replay_and_restart_game();
 		return;
     }
 

--- a/src/replay.c
+++ b/src/replay.c
@@ -226,16 +226,19 @@ byte open_replay_file(const char *filename) {
 void change_working_dir_to_sdlpop_root() {
 	char* exe_path = g_argv[0];
 	// strip away everything after the last slash or backslash in the path
-	size_t len;
-	for (len = strlen(exe_path); len >= 0; --len) {
+	int len;
+	for (len = strlen(exe_path); len > 0; --len) {
 		if (exe_path[len] == '\\' || exe_path[len] == '/') {
 			break;
 		}
 	}
-	char exe_dir[POP_MAX_PATH];
-	strncpy(exe_dir, exe_path, len);
-	exe_dir[len] = '\0';
-	chdir(exe_dir);
+	if (len > 0) {
+		char exe_dir[POP_MAX_PATH];
+		strncpy(exe_dir, exe_path, len);
+		exe_dir[len] = '\0';
+		chdir(exe_dir);
+	}
+
 };
 
 // Called in pop_main(); check whether a replay file is being opened directly (double-clicked, dragged onto .exe, etc.)

--- a/src/replay.c
+++ b/src/replay.c
@@ -251,10 +251,15 @@ void check_if_opening_replay_file() {
 				// We should read the header in advance so we know the levelset name
 				// then the game can immediately load the correct resources
 				replay_header_type header = {0};
-				char error_message[REPLAY_HEADER_ERROR_MESSAGE_MAX];
-				int ok = read_replay_header(&header, replay_fp, error_message);
+				char header_error_message[REPLAY_HEADER_ERROR_MESSAGE_MAX];
+				int ok = read_replay_header(&header, replay_fp, header_error_message);
 				if (!ok) {
-					printf("Error opening replay file: %s\n", error_message);
+					char error_message[REPLAY_HEADER_ERROR_MESSAGE_MAX];
+					snprintf(error_message, REPLAY_HEADER_ERROR_MESSAGE_MAX,
+							 "Error opening replay file: %s\n",
+							 header_error_message);
+					fprintf(stderr, error_message);
+					SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "SDLPoP", error_message, NULL);
 					fclose(replay_fp);
 					replay_fp = NULL;
 					replay_file_open = 0;

--- a/src/replay.c
+++ b/src/replay.c
@@ -51,7 +51,6 @@ typedef union replay_move_type {
 } replay_move_type;
 
 dword curr_tick = 0;
-dword saved_random_seed;
 
 FILE* replay_fp = NULL;
 byte replay_file_open = 0;
@@ -592,26 +591,27 @@ void do_replay_move() {
         stop_replay_and_restart_game();
 		return;
     }
+	if (current_level == next_level) {
+		replay_move_type curr_move;
+		curr_move.bits = moves[curr_tick];
 
-    replay_move_type curr_move;
-    curr_move.bits = moves[curr_tick];
+		control_x = curr_move.x;
+		control_y = curr_move.y;
+		control_shift = (curr_move.shift) ? -1 : 0;
 
-    control_x = curr_move.x;
-    control_y = curr_move.y;
-    control_shift = (curr_move.shift) ? -1 : 0;
-
-    if (curr_move.special == MOVE_RESTART_LEVEL) { // restart level
-        stop_sounds();
-        is_restart_level = 1;
-    } else if (curr_move.special == MOVE_EFFECT_END) {
-		stop_sounds();
-		need_level1_music = 0;
-		is_feather_fall = 0;
-	}
+		if (curr_move.special == MOVE_RESTART_LEVEL) { // restart level
+			stop_sounds();
+			is_restart_level = 1;
+		} else if (curr_move.special == MOVE_EFFECT_END) {
+			stop_sounds();
+			need_level1_music = 0;
+			is_feather_fall = 0;
+		}
 
 //    if (curr_tick > 5 ) printf("rem_tick: %d\t curr_tick: %d\tlast 5 moves: %d, %d, %d, %d, %d\n", rem_tick, curr_tick,
 //                               moves[curr_tick-4], moves[curr_tick-3], moves[curr_tick-2], moves[curr_tick-1], moves[curr_tick]);
-    ++curr_tick;
+		++curr_tick;
+	}
 }
 
 const char* original_levels_name = "Prince of Persia";

--- a/src/replay.c
+++ b/src/replay.c
@@ -147,7 +147,23 @@ int read_replay_header(replay_header_type* header, FILE* fp, char* error_message
 		return 0;
 	}
 
-	return 1; // success
+	if (is_validate_mode) {
+		static byte is_replay_info_printed = 0;
+		if (!is_replay_info_printed) {
+			printf("\nReplay created with %s.\n", header->implementation_name);
+			printf("Format: class identifier %d, version number %d, deprecation number %d.\n",
+				   class, version_number, deprecation_number);
+			if (header->levelset_name[0] == '\0') {
+				printf("Levelset: original Prince of Persia.\n");
+			} else {
+				printf("Levelset: %s.\n", header->levelset_name);
+			}
+			putchar('\n');
+			is_replay_info_printed = 1; // do this only once
+		}
+	}
+
+	return 1;
 }
 
 int num_replay_files = 0; // number of listed replays
@@ -241,39 +257,36 @@ void change_working_dir_to_sdlpop_root() {
 };
 
 // Called in pop_main(); check whether a replay file is being opened directly (double-clicked, dragged onto .exe, etc.)
-void check_if_opening_replay_file() {
-	if (!enable_replay) return;
-	if (g_argc > 1) {
-		char *filename = g_argv[1]; // file dragged on top of executable or double clicked
-		char *e = strrchr(filename, '.');
-		if (e != NULL && strcasecmp(e, ".P1R") == 0) { // valid replay filename passed as first arg
-			if (open_replay_file(filename)) {
-				change_working_dir_to_sdlpop_root();
-				current_replay_number = -1; // don't cycle when pressing Tab
-				// We should read the header in advance so we know the levelset name
-				// then the game can immediately load the correct resources
-				replay_header_type header = {0};
-				char header_error_message[REPLAY_HEADER_ERROR_MESSAGE_MAX];
-				int ok = read_replay_header(&header, replay_fp, header_error_message);
-				if (!ok) {
-					char error_message[REPLAY_HEADER_ERROR_MESSAGE_MAX];
-					snprintf(error_message, REPLAY_HEADER_ERROR_MESSAGE_MAX,
-							 "Error opening replay file: %s\n",
-							 header_error_message);
-					fprintf(stderr, error_message);
-					SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "SDLPoP", error_message, NULL);
-					fclose(replay_fp);
-					replay_fp = NULL;
-					replay_file_open = 0;
-					return;
-				}
-				if (header.uses_custom_levelset) {
-					strncpy(replay_levelset_name, header.levelset_name, sizeof(replay_levelset_name)); // use the replays's levelset
-				}
-				rewind(replay_fp); // replay file is still open and will be read in load_replay() later
-				need_start_replay = 1; // will later call start_replay(), from init_record_replay()
-			};
+void start_with_replay_file(const char *filename) {
+	if (open_replay_file(filename)) {
+		change_working_dir_to_sdlpop_root();
+		current_replay_number = -1; // don't cycle when pressing Tab
+		// We should read the header in advance so we know the levelset name
+		// then the game can immediately load the correct resources
+		replay_header_type header = {0};
+		char header_error_message[REPLAY_HEADER_ERROR_MESSAGE_MAX];
+		int ok = read_replay_header(&header, replay_fp, header_error_message);
+		if (!ok) {
+			char error_message[REPLAY_HEADER_ERROR_MESSAGE_MAX];
+			snprintf(error_message, REPLAY_HEADER_ERROR_MESSAGE_MAX,
+					 "Error opening replay file: %s\n",
+					 header_error_message);
+			fprintf(stderr, error_message);
+			fclose(replay_fp);
+			replay_fp = NULL;
+			replay_file_open = 0;
+
+			if (is_validate_mode) // Validating replays is cmd-line only, so, no sense continuing from here.
+				exit(0);
+
+			SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "SDLPoP", error_message, NULL);
+			return;
 		}
+		if (header.uses_custom_levelset) {
+			strncpy(replay_levelset_name, header.levelset_name, sizeof(replay_levelset_name)); // use the replays's levelset
+		}
+		rewind(replay_fp); // replay file is still open and will be read in load_replay() later
+		need_start_replay = 1; // will later call start_replay(), from init_record_replay()
 	}
 }
 
@@ -565,31 +578,78 @@ void restore_normal_options() {
 	use_custom_levelset = (levelset_name[0] == '\0') ? 0 : 1;
 }
 
+static void print_remaining_time() {
+	if (rem_min > 0) {
+		printf("Remaining time: %d min, %d sec, %d ticks. ",
+			   rem_min - 1, rem_tick / 12, rem_tick % 12);
+	} else {
+		printf("Elapsed time:   %d min, %d sec, %d ticks. ",
+			   -(rem_min + 1), (719 - rem_tick) / 12, (719 - rem_tick) % 12);
+	}
+	printf("(rem_min=%d, rem_tick=%d)\n", rem_min, rem_tick);
+}
+
 void start_replay() {
 	if (!enable_replay) return;
 	need_start_replay = 0;
-	list_replay_files();
-	if (num_replay_files == 0) return;
+	if (!is_validate_mode) {
+		list_replay_files();
+		if (num_replay_files == 0) return;
+	}
 	if (!load_replay()) return;
+	apply_replay_options();
 	replaying = 1;
 	curr_tick = 0;
-    apply_replay_options();
 }
 
-void stop_replay_and_restart_game() {
-	replaying = 0;
-	skipping_replay = 0;
-	restore_normal_options();
-	start_game();
+void end_replay() {
+	if (!is_validate_mode) {
+		replaying = 0;
+		skipping_replay = 0;
+		restore_normal_options();
+		start_game();
+	} else {
+		printf("\nReplay ended in level %d, room %d.\n", current_level, drawn_room);
+
+		if (Kid.alive < 0)
+			printf("Kid is alive.\n");
+		else {
+			if (text_time_total == 288 && text_time_remaining <= 1) {
+				printf("Kid is dead. (Did not press button to continue.)\n");
+			} else {
+				printf("Kid is dead.\n");
+			}
+		}
+
+		print_remaining_time();
+
+		int minute_ticks = curr_tick % 720;
+		printf("Play duration:  %d min, %d sec, %d ticks. (curr_tick=%d)\n\n",
+			   curr_tick / 720, minute_ticks / 12, minute_ticks % 12, curr_tick);
+
+		if (num_replay_ticks != curr_tick) {
+			printf("WARNING: Play duration does not match replay length. (%d ticks)\n", num_replay_ticks);
+		} else {
+			printf("Play duration matches replay length. (%d ticks)\n", num_replay_ticks);
+		}
+		exit(0);
+	}
 }
 
 void do_replay_move() {
     if (curr_tick == 0) {
         random_seed = saved_random_seed;
         seed_was_init = 1;
+
+		if (is_validate_mode) {
+			printf("Replay started in level %d, room %d.\n", current_level, drawn_room);
+			print_remaining_time();
+			skipping_replay = 1;
+			replay_seek_target = replay_seek_2_end;
+		}
     }
     if (curr_tick == num_replay_ticks) { // replay is finished
-        stop_replay_and_restart_game();
+		end_replay();
 		return;
     }
 	if (current_level == next_level) {
@@ -598,7 +658,12 @@ void do_replay_move() {
 
 		control_x = curr_move.x;
 		control_y = curr_move.y;
-		control_shift = (curr_move.shift) ? -1 : 0;
+
+		// Ignore shift if the kid is dead: restart moves are hard-coded as a 'special move'.
+		if (rem_min != 0 && Kid.alive > 6)
+			control_shift = 0;
+		else
+			control_shift = (curr_move.shift) ? -1 : 0;
 
 		if (curr_move.special == MOVE_RESTART_LEVEL) { // restart level
 			stop_sounds();

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -601,6 +601,12 @@ int __pascal far process_key() {
 		break;
 		case SDL_SCANCODE_F9:
 		case SDL_SCANCODE_F9 | WITH_SHIFT:
+#ifdef USE_REPLAY
+			if (recording) {
+				answer_text = "NO QUICKLOAD"; // quickloading would mess up the replay!
+				need_show_text = 1;
+			} else
+#endif
 			need_quick_load = 1;
 		break;
 #ifdef USE_REPLAY

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -1113,6 +1113,10 @@ void __pascal far check_the_end() {
 		drawn_room = next_room;
 		load_room_links();
 		if (current_level == 14 && drawn_room == 5) {
+#ifdef USE_REPLAY
+			if (recording) stop_recording();
+			if (replaying) stop_replay_and_restart_game();
+#endif
 			// Special event: end of game
 			end_sequence();
 		}

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -621,8 +621,8 @@ int __pascal far process_key() {
 			else { // should start recording
 				start_recording();
 			}
-			break;
-#endif // USE_RECORD_REPLAY
+		break;
+#endif // USE_REPLAY
 #endif // USE_QUICKSAVE
 	}
 	if (cheats_enabled) {

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -475,7 +475,10 @@ int __pascal far process_key() {
 			if (key == SDL_SCANCODE_TAB || need_start_replay) {
 				start_replay();
 			}
-			else
+			else if (key == (SDL_SCANCODE_TAB | WITH_CTRL)) {
+				start_level = first_level;
+				start_recording();
+			} else
 			#endif
 			if (key == (SDL_SCANCODE_L | WITH_CTRL)) { // ctrl-L
 				if (!load_game()) return 0;

--- a/src/seg001.c
+++ b/src/seg001.c
@@ -542,6 +542,9 @@ void __pascal far do_flash(short color) {
 }
 
 void delay_ticks(Uint32 ticks) {
+#ifdef USE_REPLAY
+	if (replaying && skipping_replay) return;
+#endif
 	SDL_Delay(ticks *(1000/60));
 }
 

--- a/src/seg002.c
+++ b/src/seg002.c
@@ -358,10 +358,6 @@ void __pascal far exit_room() {
 
 // seg002:0486
 int __pascal far goto_other_room(short direction) {
-#ifdef USE_REPLAY
-	if (skipping_replay && replay_seek_target == replay_seek_0_next_room) skipping_replay = 0;
-#endif
-
 	short opposite_dir;
 	Char.room = ((byte*)&level.roomlinks[Char.room - 1])[direction];
 	if (direction == 0) {
@@ -471,6 +467,9 @@ short __pascal far leave_room() {
 		break;
 	}
 	goto_other_room(leave_dir);
+#ifdef USE_REPLAY
+	if (skipping_replay && replay_seek_target == replay_seek_0_next_room) skipping_replay = 0;
+#endif
 	return leave_dir;
 }
 

--- a/src/seg002.c
+++ b/src/seg002.c
@@ -358,6 +358,10 @@ void __pascal far exit_room() {
 
 // seg002:0486
 int __pascal far goto_other_room(short direction) {
+#ifdef USE_REPLAY
+	if (skipping_replay && replay_seek_target == replay_seek_0_next_room) skipping_replay = 0;
+#endif
+
 	short opposite_dir;
 	Char.room = ((byte*)&level.roomlinks[Char.room - 1])[direction];
 	if (direction == 0) {

--- a/src/seg003.c
+++ b/src/seg003.c
@@ -107,6 +107,12 @@ void __pascal far play_level(int level_number) {
 		stop_sounds();
 		#ifdef USE_REPLAY
 		if (replaying) replay_restore_level();
+		if (skipping_replay) {
+			if (replay_seek_target == replay_seek_0_next_room ||
+				replay_seek_target == replay_seek_1_next_level
+			)
+				skipping_replay = 0; // resume replay from here
+		}
 		#endif
 		draw_level_first();
 		show_copyprot(0);

--- a/src/seg006.c
+++ b/src/seg006.c
@@ -614,6 +614,10 @@ void __pascal far play_seq() {
 						play_sound(sound_18_drink); // drink
 						break;
 					case SND_LEVEL: // level
+#ifdef USE_REPLAY
+						if (recording || replaying) break; // don't do end level music in replays
+#endif
+
 						if (is_sound_on) {
 							if (current_level == 4) {
 								play_sound(sound_32_shadow_music); // end level with shadow (level 4)

--- a/src/seg006.c
+++ b/src/seg006.c
@@ -635,6 +635,7 @@ void __pascal far play_seq() {
 				// regardless of how long the sound is still playing *after* this frame.
 				// Animations (e.g. torch) can change the seed!
 				keep_last_seed = 1;
+				if (replaying && skipping_replay) stop_sounds();
 #endif
 				break;
 			case SEQ_GET_ITEM: // get item

--- a/src/seg006.c
+++ b/src/seg006.c
@@ -630,6 +630,12 @@ void __pascal far play_seq() {
 				break;
 			case SEQ_END_LEVEL: // end level
 				++next_level;
+#ifdef USE_REPLAY
+				// Preserve the seed in this frame, to ensure reproducibility of the replay in the next level,
+				// regardless of how long the sound is still playing *after* this frame.
+				// Animations (e.g. torch) can change the seed!
+				keep_last_seed = 1;
+#endif
 				break;
 			case SEQ_GET_ITEM: // get item
 				if (*(SEQTBL_0 + Char.curr_seq++) == 1) {

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -113,7 +113,7 @@ const char* __pascal far check_param(const char *param) {
 
 		// List of params that expect a specifier ('sub-') arg directly after it (e.g. the mod's name, after "mod" arg)
 		// Such sub-args may conflict with the normal params (so, we should 'skip over' them)
-		static const char params_with_one_subparam[][8] = { "mod", /*...*/ };
+		static const char params_with_one_subparam[][16] = { "mod", "validate", /*...*/ };
 
 		bool curr_arg_has_one_subparam = false;
 		int i;
@@ -1948,6 +1948,10 @@ void __pascal far set_gr_mode(byte grmode) {
 	if (use_correct_aspect_ratio && pop_window_width == 640 && pop_window_height == 400) {
 		pop_window_height = 480;
 	}
+
+#ifdef USE_REPLAY
+	if (!is_validate_mode) // run without a window if validating a replay
+#endif
 	window_ = SDL_CreateWindow(WINDOW_TITLE,
 										  SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
 										  pop_window_width, pop_window_height, flags);
@@ -2720,7 +2724,7 @@ int __pascal do_wait(int timer_index) {
 
 void __pascal do_simple_wait(int timer_index) {
 #ifdef USE_REPLAY
-	if (replaying && skipping_replay) return;
+	if ((replaying && skipping_replay) || is_validate_mode) return;
 #endif
 
 	while (! has_timer_stopped(timer_index)) {

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -1880,6 +1880,11 @@ void free_sound(sound_buffer_type far *buffer) {
 
 // seg009:7220
 void __pascal far play_sound_from_buffer(sound_buffer_type far *buffer) {
+	
+#ifdef USE_REPLAY
+	if (replaying && skipping_replay) return;
+#endif
+
 	// stub
 	if (buffer == NULL) {
 		printf("Tried to play NULL sound.\n");
@@ -1994,6 +1999,9 @@ void __pascal far set_gr_mode(byte grmode) {
 }
 
 void request_screen_update() {
+#ifdef USE_REPLAY
+	if (replaying && skipping_replay) return;
+#endif
 	if (!screen_updates_suspended) {
 		SDL_UpdateTexture(sdl_texture_, NULL, onscreen_surface_->pixels, onscreen_surface_->pitch);
 		SDL_RenderClear(renderer_);
@@ -2491,6 +2499,9 @@ Uint32 timer_callback(Uint32 interval, void *param) {
 }
 
 void __pascal start_timer(int timer_index, int length) {
+#ifdef USE_REPLAY
+	if (replaying && skipping_replay) return;
+#endif
 #ifndef USE_COMPAT_TIMER
 	if (timer_handles[timer_index]) {
 		remove_timer(timer_index);
@@ -2708,6 +2719,10 @@ int __pascal do_wait(int timer_index) {
 }
 
 void __pascal do_simple_wait(int timer_index) {
+#ifdef USE_REPLAY
+	if (replaying && skipping_replay) return;
+#endif
+
 	while (! has_timer_stopped(timer_index)) {
 		idle();
 	}

--- a/src/types.h
+++ b/src/types.h
@@ -1020,6 +1020,12 @@ enum replay_special_moves {
 	MOVE_RESTART_LEVEL = 1, // player pressed Ctrl+A
 	MOVE_EFFECT_END = 2,    // music stops, causing the end of feather effect or level 1 crouch immobilization
 };
+
+enum replay_seek_targets {
+	replay_seek_0_next_room = 0,
+	replay_seek_1_next_level = 1,
+	replay_seek_2_end = 2,
+};
 #endif
 
 #define COUNT(array) (sizeof(array)/sizeof(array[0]))


### PR DESCRIPTION
Like #121 this is a follow-up to #120 

This adds skipping through replays.
To use:

* While in a replay, press F to skip forward to the next room, or press Shift+F to skip forward to the next level in the replay.
* From the command-line, you can check that a replay works as intended without actually sitting through the whole replay. Use a command like this:
`prince validate "replays/replay.p1r`

Example output from the `validate` command-line argument:
```
Replay created with SDLPoP v1.17.
Format: class identifier 0, version number 101, deprecation number 1.
Levelset: original Prince of Persia.

Replay started in level 4, room 1.
Remaining time: 47 min, 29 sec, 7 ticks. (rem_min=48, rem_tick=355)

Replay ended in level 14, room 5.
Kid is alive.
Remaining time: 29 min, 45 sec, 3 ticks. (rem_min=30, rem_tick=543)
Play duration:  18 min, 6 sec, 8 ticks. (curr_tick=13040)

Play duration matches replay length. (13040 ticks)
```
