### PR TITLE
Tweaked the automatic input mode selection

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -33,6 +33,8 @@ The authors of this program may be contacted at http://forum.princed.org
 #define SDLPOP_VERSION "1.17"
 #define WINDOW_TITLE "Prince of Persia (SDLPoP) v" SDLPOP_VERSION
 
+#define JOY_THRESHOLD 8000
+
 // Enable or disable fading.
 // Fading used to be very buggy, but now it works correctly.
 #define USE_FADE

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -1171,7 +1171,6 @@ void __pascal far check_fall_flo() {
 
 void get_joystick_state(int raw_x, int raw_y, int axis_state[2]) {
 
-#define JOY_THRESHOLD 8000
 #define DEGREES_TO_RADIANS (M_PI/180.0)
 
 	// check if the X/Y position is within the 'dead zone' of the joystick

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -2616,7 +2616,9 @@ void idle() {
 
 #ifdef USE_AUTO_INPUT_MODE
 					switch (scancode) {
-						// Keys that are used for keyboard control: (except shift)
+						// Keys that are used for keyboard control:
+						case SDL_SCANCODE_LSHIFT:
+						case SDL_SCANCODE_RSHIFT:
 						case SDL_SCANCODE_LEFT:
 						case SDL_SCANCODE_RIGHT:
 						case SDL_SCANCODE_UP:
@@ -2631,7 +2633,10 @@ void idle() {
 						case SDL_SCANCODE_KP_7:
 						case SDL_SCANCODE_KP_8:
 						case SDL_SCANCODE_KP_9:
-							if (!is_keyboard_mode) last_key_scancode = SDL_SCANCODE_K | WITH_CTRL; // force keyboard mode
+							if (!is_keyboard_mode) {
+								is_keyboard_mode = 1;
+								is_joyst_mode = 0;
+							}
 					}
 #endif
 				}
@@ -2641,14 +2646,23 @@ void idle() {
 				key_states[event.key.keysym.scancode] = 0;
 				break;
 			case SDL_CONTROLLERAXISMOTION:
+				if (event.caxis.axis < 6) {
+					joy_axis[event.caxis.axis] = event.caxis.value;
+
 #ifdef USE_AUTO_INPUT_MODE
-				if (!is_joyst_mode) last_key_scancode = SDL_SCANCODE_J | WITH_CTRL; // force joystick mode
+					if (!is_joyst_mode && (event.caxis.value >= JOY_THRESHOLD || event.caxis.value <= -JOY_THRESHOLD)) {
+						is_joyst_mode = 1;
+						is_keyboard_mode = 0;
+					}
 #endif
-				if (event.caxis.axis < 6) joy_axis[event.caxis.axis] = event.caxis.value;
+				}
 				break;
 			case SDL_CONTROLLERBUTTONDOWN:
 #ifdef USE_AUTO_INPUT_MODE
-				if (!is_joyst_mode) last_key_scancode = SDL_SCANCODE_J | WITH_CTRL; // force joystick mode
+				if (!is_joyst_mode) {
+					is_joyst_mode = 1;
+					is_keyboard_mode = 0;
+				}
 #endif
 				switch (event.cbutton.button)
 				{


### PR DESCRIPTION
* Fixed not being able to start the game from the title screen by pressing shift (it unfortunately seems impossible to distinguish whether pressing shift was meant as control input, or as part of a hotkey, so we have to assume that it was meant as control...)
* Check that the controller axis value is outside the dead zone to prevent accidental input being registered.
* Changed the switching to be immediately processed and made the switching silent. (Not sure if this is the right choice, but it feels very seamless)
