### PR TITLE
Fix compiling with MSVC and improve build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ mods/*/
 *.obj
 *.elf
 
+# Compiled resource files
+*.res
+
 # Precompiled Headers
 *.gch
 *.pch
@@ -40,7 +43,6 @@ mods/*/
 *.i*86
 *.x86_64
 *.hex
-*.bat
 prince
 !data/PRINCE/
 
@@ -57,6 +59,9 @@ src/*_private.*
 src/.idea/
 src/cmake-build*/
 build/
+
+# Visual Studio
+.vs/
 
 # Windows thumbnail cache
 Thumbs.db

--- a/doc/Readme.txt
+++ b/doc/Readme.txt
@@ -264,7 +264,7 @@ DEVELOPING
 Q: How do I (re)compile it?
 A:
 Prerequisites for all platforms:
-	Make sure that you have the development versions of the "SDL", "SDL_image" and "SDL_mixer" (since SDLPoP 1.13) libraries installed.
+	Make sure that you have the development versions of the "SDL2", "SDL2_image" and "SDL2_mixer" (since SDLPoP 1.13) libraries installed.
 
 Windows:
 	If you are using Dev-C++:
@@ -277,7 +277,26 @@ Windows:
 		To install these, just extract the contents of the i686-w64-mingw32 folder from each archive to the Dev-Cpp folder.
 		To compile, open one of the .dev files and click the compile icon.
 
-	You can also use CMake.
+    Building with Visual Studio:
+        Run build.bat in the src/ directory.
+        For this to work, you first need to do two other things:
+            a) Run vsvarsall.bat from the command line, with either 'x86' or 'x64' as a parameter.
+               This batch file is included with all installations of MS Visual Studio, but its exact location may vary.
+               For VS2017, the command you should run might look like this:
+               call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86
+               This step sets up various environment variables, to enable running the compiler from the command line.
+            b) Set up the environment variable 'SDL2' to point to the SDL2 development library files.
+               To do this, you can use a command like so:
+               set "SDL2=C:\libraries\SDL2-2.0.5"
+               You can get the SDL2 library files from here: (download the Visual C++ 32/64-bit development package)
+               https://www.libsdl.org/download-2.0.php
+            (You could create a small batch file to automate the above steps on your system.)
+        Alternatively, you can also build SDLPoP using MSVC with NMake (use the makefile src/NMakefile).
+
+	You can also use CMake, in conjunction with the MinGW-w64 toolchain.
+	    You could either invoke CMake from the command line yourself, or use an IDE that uses CMake internally.
+	    As an example, CLion uses CMake as its project model.
+	    If you are using CLion as your IDE, you can simply load the src/ directory as a project.
 
 GNU/Linux:
 	You can install the libraries with apt-get or a package manager.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,23 +3,45 @@ project(SDLPoP)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=gnu99")
 
+# have CMake output binaries to the directory that contains the source files
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${SDLPoP_SOURCE_DIR}/..")
+
 if (WIN32)
+    if (MSVC)
+        # Don't let Visual Studio run CMake
+        message(SEND_ERROR "To build using MSVC on Windows, you can use NMake or run build.bat.")
+        return()
+    endif()
+
     # Use the -mwindows compiler flag when compiling with MinGW to hide the console window
     # Only do this when not in debug mode
     if (NOT (CMAKE_BUILD_TYPE STREQUAL "Debug"))
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mwindows")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mwindows")
     endif (NOT (CMAKE_BUILD_TYPE STREQUAL "Debug"))
-endif(WIN32)
 
-# have CMake output binaries to the directory that contains the source files
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${SDLPoP_SOURCE_DIR}/..")
+    # SDLPoP requires the SDL_2, SDL2_image and SDL2_mixer development libraries.
+    # You can pass the SDL2 location to CMake like so: -DSDL2="C:/work/libraries/SDL2-2.0.5"
+    # Or alternatively, specify the SDL2 location below:
 
-# if SDL_2, SDL2_image and SDL2_mixer are not in the toolchain/build environment, specify /include and /lib paths:
+    #set(SDL2 "C:/work/libraries/SDL2-2.0.5")
 
-#set(DIR_SDL2 "C:/SDL2-2.0.3")
-#include_directories(${DIR_SDL2}/include)
-#link_directories(${DIR_SDL2}/lib)
+    # If the location of SDL2 is not specified, we will try to guess it.
+    if (NOT(DEFINED SDL2))
+        cmake_policy(SET CMP0015 NEW) # suppress warning about relative paths
+        set(SDL2 "../../SDL2-2.0.5")
+    endif()
+
+    # Automatically detect whether we need the x86 or x64 version of the SDL2 library.
+    if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(SDL2_ARCH "x86_64-w64-mingw32")
+    else()
+        set(SDL2_ARCH "i686-w64-mingw32")
+    endif()
+
+    include_directories(${SDL2}/${SDL2_ARCH}/include)
+    link_directories(${SDL2}/${SDL2_ARCH}/lib)
+endif()
 
 set(SOURCE_FILES
         main.c
@@ -28,6 +50,7 @@ set(SOURCE_FILES
         data.c
         data.h
         proto.h
+        types.h
         seg000.c
         seg001.c
         seg002.c
@@ -41,10 +64,9 @@ set(SOURCE_FILES
         seqtbl.c
         options.c
         replay.c
-        types.h
-        icon.rc
         lighting.c
         screenshot.c
+        icon.rc
         )
 add_executable(prince ${SOURCE_FILES})
 

--- a/src/NMakefile
+++ b/src/NMakefile
@@ -1,5 +1,5 @@
 
-OBJ = main.obj data.obj seg000.obj seg001.obj seg002.obj seg003.obj seg004.obj seg005.obj seg006.obj seg007.obj seg008.obj seg009.obj seqtbl.obj replay.obj options.obj
+OBJ = main.obj data.obj seg000.obj seg001.obj seg002.obj seg003.obj seg004.obj seg005.obj seg006.obj seg007.obj seg008.obj seg009.obj seqtbl.obj replay.obj options.obj lighting.obj screenshot.obj
 
 sdl = "..\SDL2-2.0.4"
 LIBS = $(sdl)\lib\x86\SDL2main.lib $(sdl)\lib\x86\SDL2.lib $(sdl)\lib\x86\SDL2_image.lib $(sdl)\lib\x86\SDL2_mixer.lib
@@ -12,13 +12,16 @@ cflags = $(cflags) /MDd /Od
 cflags = $(cflags) /MD /O2
 !ENDIF
 
+cflags = $(cflags) /nologo /fp:fast /GR- /wd4048
+
 all: prince.exe
 
 .c.obj:
-	$(cc) $(cdebug) $(cflags) $(cvars) /I. /I$(sdl)\include $<
+	$(cc) $(cdebug) $(cflags) $(cvars) /I. /I"$(sdl)\include" $<
 
 prince.exe: $(OBJ)
-	$(link) $(ldebug) $(conflags) -out:prince.exe $(conlibs) $(OBJ) $(LIBS)
+	$(link) $(ldebug) $(conflags) -out:..\prince.exe $(conlibs) $(OBJ) $(LIBS)
 
 clean:
 	del *.obj prince.exe
+	

--- a/src/build.bat
+++ b/src/build.bat
@@ -1,0 +1,65 @@
+@echo off
+setlocal
+cd %~dp0
+
+:: Check that we have access to the MSVC compiler.
+
+where /q cl
+if ERRORLEVEL 1 (
+  echo Problem^: the MSVC compiler ^(cl^) cannot not found.
+  echo The solution is to run vcvarsall.bat, which sets the necessary environment variables.
+  echo,
+  echo Example command for VS2017^:
+  echo call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86
+  echo,
+  echo Example command for VS2015^:
+  echo call "%%VS140COMNTOOLS%%..\..\VC\vcvarsall.bat" x86
+  exit /b
+)
+
+:: To override the directory for SDL2 library files, simply set the SDL environment variable in the command shell.
+:: (You could do that from the command-line, or from a wrapper script that calls this one.)
+
+if [%SDL2%]==[] (
+  set SDL2=..\..\SDL2-2.0.5
+)
+
+if not exist %SDL2% (
+  echo Problem^: Could not find SDL2 directory.
+  echo Tried to look here^: %SDL2%
+  echo,
+  echo To specify the SDL2 directory, set the SDL2 environment variable.
+  echo Example command:
+  echo set "SDL2=C:\work\libraries\SDL2-2.0.5"
+  exit /b
+)
+
+:: To choose the build configuration, specify either "debug" or "release" as command-line parameter for this build script.
+
+if [%1]==[debug] goto build_type_debug
+if [%1]==[release] goto build_type_release
+echo Build type not specified, compiling in release mode...
+echo To specify the build type, run as "build.bat debug" or "build.bat release".
+
+:build_type_debug
+set BuildTypeCompilerFlags= /MDd /Od
+set PreprocessorDefinitions= -DDEBUG=1
+goto compile
+
+:build_type_release
+set BuildTypeCompilerFlags= /MD /O2
+set PreprocessorDefinitions=
+
+:compile
+set SourceFiles= main.c data.c seg000.c seg001.c seg002.c seg003.c seg004.c seg005.c seg006.c seg007.c seg008.c seg009.c seqtbl.c replay.c options.c lighting.c screenshot.c
+set CommonCompilerFlags= /nologo /fp:fast /GR- /wd4048 %PreprocessorDefinitions% /I"%SDL2%\include"
+set CommonLinkerFlags= /subsystem:windows /libpath:"%SDL2%\lib\%VSCMD_ARG_TGT_ARCH%" SDL2main.lib SDL2.lib SDL2_image.lib SDL2_mixer.lib icon.res /out:..\prince.exe
+
+rc /nologo /fo icon.res icon.rc
+cl %BuildTypeCompilerFlags% %CommonCompilerFlags% %SourceFiles% /link %CommonLinkerFlags%
+
+:: Cleanup
+
+del icon.res
+del *.obj
+echo Output: ..\prince.exe

--- a/src/common.h
+++ b/src/common.h
@@ -31,12 +31,7 @@ extern "C" {
 #include <fcntl.h>
 #include <string.h>
 #include <sys/stat.h>
-#ifdef _MSC_VER
-#include <io.h>
-#include "unistd_win.h"
-#else
-#include <unistd.h>
-#endif
+#include <stdint.h>
 #include <stdbool.h>
 
 #include "config.h"

--- a/src/replay.c
+++ b/src/replay.c
@@ -19,9 +19,20 @@ The authors of this program may be contacted at http://forum.princed.org
 */
 
 #include "common.h"
-#include <dirent.h>
 #include <time.h>
 #include <sys/stat.h>
+
+// Directory listing using dirent.h is available using MinGW on Windows, but not using MSVC (need to use Win32 API).
+// NOTE: If we are using MinGW, we'll opt to use the Win32 API as well: dirent.h would just wrap Win32 anyway!
+#ifdef _WIN32
+#define USE_WIN32_API_FOR_LISTING_REPLAY_FILES
+#endif
+
+#ifdef USE_WIN32_API_FOR_LISTING_REPLAY_FILES
+#include <windows.h>
+#else
+#include <dirent.h>
+#endif
 
 #ifdef USE_REPLAY
 
@@ -177,52 +188,136 @@ static int compare_replay_creation_time(const void* a, const void* b)
 	return (int) difftime( ((replay_info_type*)b)->creation_time, ((replay_info_type*)a)->creation_time );
 }
 
+// OS abstraction for listing directory contents (for list_replay_files() below)
+// - Under GNU/Linux, etc (or if compiling with MinGW on Windows), we can use dirent.h
+// - Under Windows, we'd like to directly call the Win32 API. (Note: MSVC does not include dirent.h)
+
+#ifdef USE_WIN32_API_FOR_LISTING_REPLAY_FILES
+
+typedef struct directory_listing_data_type {
+    char search_pattern[POP_MAX_PATH];
+    WIN32_FIND_DATA find_data;
+    HANDLE search_handle;
+
+} directory_listing_type;
+
+static inline bool init_directory_listing_and_find_first_file(directory_listing_type *data) {
+    snprintf( data->search_pattern, POP_MAX_PATH, "%s\\*.p1r", replays_folder);
+    data->search_handle = FindFirstFileA( data->search_pattern, &data->find_data );
+    return (data->search_handle != INVALID_HANDLE_VALUE);
+}
+
+static inline char* get_current_filename_from_directory_listing(directory_listing_type* data) {
+    return data->find_data.cFileName;
+}
+
+static inline bool find_next_file(directory_listing_type* data) {
+    return (bool) FindNextFileA( data->search_handle, &data->find_data );
+}
+
+static inline void directory_listing_close(directory_listing_type *data) {
+    FindClose(data->search_handle);
+}
+
+#else // use dirent.h API for listing replay files
+
+typedef struct directory_listing_data_type {
+    DIR* dp;
+    char* found_filename;
+
+} directory_listing_type;
+
+static inline bool init_directory_listing_and_find_first_file(directory_listing_type *data) {
+    bool ok = false;
+    data->dp = opendir(replays_folder);
+    if (data->dp != NULL) {
+        struct dirent* ep;
+        while ((ep = readdir(data->dp))) {
+            char *ext = strrchr(ep->d_name, '.');
+            if (ext != NULL && strcasecmp(ext, ".p1r") == 0) {
+                data->found_filename = ep->d_name;
+                ok = true;
+                break;
+            }
+        }
+    }
+    return ok;
+}
+
+static inline char* get_current_filename_from_directory_listing(directory_listing_type* data) {
+    return data->found_filename;
+}
+
+static inline bool find_next_file(directory_listing_type* data) {
+    bool ok = false;
+    struct dirent* ep;
+    while ((ep = readdir(data->dp))) {
+        char *ext = strrchr(ep->d_name, '.');
+        if (ext != NULL && strcasecmp(ext, ".p1r") == 0) {
+            data->found_filename = ep->d_name;
+            ok = true;
+            break;
+        }
+    }
+    return ok;
+}
+
+static inline void directory_listing_close(directory_listing_type *data) {
+    closedir(data->dp);
+}
+
+#endif
+
+
 void list_replay_files() {
-	DIR* dp;
-	struct dirent* ep;
 
     if (replay_list == NULL) {
         // need to allocate enough memory to store info about all replay files in the directory
-        replay_list = malloc(max_replay_files * sizeof(replay_info_type)); // will realloc() later if > 256 files exist
+        replay_list = malloc( max_replay_files * sizeof( replay_info_type ) ); // will realloc() later if > 256 files exist
     }
 
     num_replay_files = 0;
-	dp = opendir(replays_folder);
-	if (dp != NULL) {
-		while ((ep = readdir(dp))) {
-			char* ext = strrchr(ep->d_name, '.');
-			if (ext != NULL && strcasecmp(ext, ".p1r") == 0) {
-				++num_replay_files;
-                if (num_replay_files > max_replay_files) {
-                    // too many files, expand the memory available for replay_list
-                    max_replay_files += 128;
-                    replay_list = realloc(replay_list, max_replay_files * sizeof(replay_info_type));
-                }
-                replay_info_type* replay_info = &replay_list[num_replay_files-1]; // current replay file
-				memset(replay_info, 0, sizeof(replay_info_type));
-                // store the filename of the replay
-				snprintf(replay_info->filename, POP_MAX_PATH, "%s/%s", replays_folder, ep->d_name);
-				// get the creation time
-				struct stat st;
-				if (stat(replay_info->filename, &st) == 0) {
-					replay_info->creation_time = st.st_ctime;
-				}
-				// read and store the levelset name associated with the replay
-				FILE* fp = fopen(replay_info->filename, "rb");
-				int ok = 0;
-				if (fp != NULL) {
-					ok = read_replay_header(&replay_info->header, fp, NULL);
-					fclose(fp);
-				}
-				if (!ok) --num_replay_files; // scrap the file if it is not compatible
-			}
-		}
-	}
 
-	if (num_replay_files > 1) {
-		// sort listed replays by their creation date
-		qsort(replay_list, num_replay_files, sizeof(replay_info_type), compare_replay_creation_time);
-	}
+    directory_listing_type directory_listing = {0};
+    if (!init_directory_listing_and_find_first_file(&directory_listing)) {
+        return;
+    }
+
+    do {
+        ++num_replay_files;
+        if (num_replay_files > max_replay_files) {
+            // too many files, expand the memory available for replay_list
+            max_replay_files += 128;
+            replay_list = realloc( replay_list, max_replay_files * sizeof( replay_info_type ) );
+        }
+        replay_info_type* replay_info = &replay_list[num_replay_files - 1]; // current replay file
+        memset( replay_info, 0, sizeof( replay_info_type ) );
+        // store the filename of the replay
+        snprintf( replay_info->filename, POP_MAX_PATH, "%s/%s", replays_folder,
+                  get_current_filename_from_directory_listing(&directory_listing) );
+
+        // get the creation time
+        struct stat st;
+        if (stat( replay_info->filename, &st ) == 0) {
+            replay_info->creation_time = st.st_ctime;
+        }
+        // read and store the levelset name associated with the replay
+        FILE* fp = fopen( replay_info->filename, "rb" );
+        int ok = 0;
+        if (fp != NULL) {
+            ok = read_replay_header( &replay_info->header, fp, NULL );
+            fclose( fp );
+        }
+        if (!ok) --num_replay_files; // scrap the file if it is not compatible
+
+    } while (find_next_file(&directory_listing));
+
+    directory_listing_close(&directory_listing);
+
+    if (num_replay_files > 1) {
+        // sort listed replays by their creation date
+        qsort( replay_list, (size_t) num_replay_files, sizeof( replay_info_type ), compare_replay_creation_time );
+    }
 };
 
 byte open_replay_file(const char *filename) {

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -145,6 +145,11 @@ int __pascal far pop_wait(int timer_index,int time) {
 	return do_wait(timer_index);
 }
 
+// S_ISREG may not be defined under MSVC
+#if defined(_MSC_VER) && !defined(S_ISREG)
+#define S_ISREG(mode)  (((mode) & S_IFMT) == S_IFREG)
+#endif
+
 static FILE* open_dat_from_root_or_data_dir(const char* filename) {
 	FILE* fp = NULL;
 	fp = fopen(filename, "rb");
@@ -975,13 +980,13 @@ const rect_type far *__pascal draw_text(const rect_type far *rect_ptr,int x_alig
 	num_lines = 0;
 	int rem_length = length;
 	const char* line_start = text;
-	static const int max_lines = 100;
-	const char* line_starts[max_lines];
-	int line_lengths[max_lines];
+    #define MAX_LINES 100
+	const char* line_starts[MAX_LINES];
+	int line_lengths[MAX_LINES];
 	do {
 		int line_length = find_linebreak(line_start, rem_length, rect_width, x_align);
 		if (line_length == 0) break;
-		if (num_lines >= max_lines) {
+		if (num_lines >= MAX_LINES) {
 			//... ERROR!
 			printf("draw_text(): Too many lines!\n");
 			quit(1);
@@ -1597,7 +1602,7 @@ void channel_finished(int channel) {
 	event.user.code = userevent_SOUND;
 	SDL_PushEvent(&event);
 }
-void music_finished() {
+void music_finished(void) {
 	channel_finished(-1);
 }
 #endif

--- a/src/types.h
+++ b/src/types.h
@@ -21,10 +21,18 @@ The authors of this program may be contacted at http://forum.princed.org
 #ifndef TYPES_H
 #define TYPES_H
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_image.h>
-#ifdef USE_MIXER
-#include <SDL2/SDL_mixer.h>
+#if !defined(_MSC_VER)
+# include <SDL2/SDL.h>
+# include <SDL2/SDL_image.h>
+# ifdef USE_MIXER
+# include <SDL2/SDL_mixer.h>
+# endif
+#else
+# include <SDL.h>
+# include <SDL_image.h>
+# ifdef USE_MIXER
+# include <SDL_mixer.h>
+# endif
 #endif
 
 #if SDL_BYTEORDER != SDL_LIL_ENDIAN


### PR DESCRIPTION
Changes:
* Added OS abstraction for directory listing in replay.c. (credits to @segrax for his work in #118, I could base the Win32 code on his code!)
* Other minor code fixes, to make the source code play well with the MSVC compiler.
* Added build.bat for compiling from the command-line, using the MSVC toolset. Added explanation in doc/Readme.txt.
* Updated NMakeFile (added lighting.obj and screenshot.obj; output prince.exe to the base dir; tweaked the compiler options a bit)
* Removed unistd_win.h, because it does not seem to be needed (and, incidentally, in common.h, including unistd.h also doesn't appear to be necessary...)
* CMakeLists.txt: Prevent Visual Studio from running CMake (one should use build.bat or NMake instead)
* CMakeLists.txt: For SDL2 include and lib directories, automatically pick the right architecture (x86 or x64), so you don't need to manually specify the architecture-specific subdirectories from the SDL2 download package.