### PR TITLE
Update CMake and MSVC build scripts; fix unistd.h not found in MSVC

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,15 +21,15 @@ if (WIN32)
     endif (NOT (CMAKE_BUILD_TYPE STREQUAL "Debug"))
 
     # SDLPoP requires the SDL_2, SDL2_image and SDL2_mixer development libraries.
-    # You can pass the SDL2 location to CMake like so: -DSDL2="C:/work/libraries/SDL2-2.0.5"
+    # You can pass the SDL2 location to CMake like so: -DSDL2="C:/work/libraries/SDL2-2.0.6"
     # Or alternatively, specify the SDL2 location below:
 
-    #set(SDL2 "C:/work/libraries/SDL2-2.0.5")
+    #set(SDL2 "C:/work/libraries/SDL2-2.0.6")
 
     # If the location of SDL2 is not specified, we will try to guess it.
     if (NOT(DEFINED SDL2))
         cmake_policy(SET CMP0015 NEW) # suppress warning about relative paths
-        set(SDL2 "../../SDL2-2.0.5")
+        set(SDL2 "../../SDL2-2.0.6")
     endif()
 
     # Automatically detect whether we need the x86 or x64 version of the SDL2 library.

--- a/src/build.bat
+++ b/src/build.bat
@@ -21,7 +21,7 @@ if ERRORLEVEL 1 (
 :: (You could do that from the command-line, or from a wrapper script that calls this one.)
 
 if [%SDL2%]==[] (
-  set SDL2=..\..\SDL2-2.0.5
+  set SDL2=..\..\SDL2-2.0.6
 )
 
 if not exist %SDL2% (
@@ -30,7 +30,7 @@ if not exist %SDL2% (
   echo,
   echo To specify the SDL2 directory, set the SDL2 environment variable.
   echo Example command:
-  echo set "SDL2=C:\work\libraries\SDL2-2.0.5"
+  echo set "SDL2=C:\work\libraries\SDL2-2.0.6"
   exit /b
 )
 
@@ -52,14 +52,20 @@ set PreprocessorDefinitions=
 
 :compile
 set SourceFiles= main.c data.c seg000.c seg001.c seg002.c seg003.c seg004.c seg005.c seg006.c seg007.c seg008.c seg009.c seqtbl.c replay.c options.c lighting.c screenshot.c
-set CommonCompilerFlags= /nologo /fp:fast /GR- /wd4048 %PreprocessorDefinitions% /I"%SDL2%\include"
-set CommonLinkerFlags= /subsystem:windows /libpath:"%SDL2%\lib\%VSCMD_ARG_TGT_ARCH%" SDL2main.lib SDL2.lib SDL2_image.lib SDL2_mixer.lib icon.res /out:..\prince.exe
+set CommonCompilerFlags= /nologo /MP /fp:fast /GR- /wd4048 %PreprocessorDefinitions% /I"%SDL2%\include"
+set CommonLinkerFlags= /subsystem:windows,5.01 /libpath:"%SDL2%\lib\%VSCMD_ARG_TGT_ARCH%" SDL2main.lib SDL2.lib SDL2_image.lib SDL2_mixer.lib icon.res /out:..\prince.exe
 
 rc /nologo /fo icon.res icon.rc
 cl %BuildTypeCompilerFlags% %CommonCompilerFlags% %SourceFiles% /link %CommonLinkerFlags%
 
-:: Cleanup
+if %ERRORLEVEL% == 0 (goto success)
+echo There were errors.
+goto cleanup
 
+:success
+echo Output: ..\prince.exe
+
+:cleanup
 del icon.res
 del *.obj
-echo Output: ..\prince.exe
+

--- a/src/replay.c
+++ b/src/replay.c
@@ -20,7 +20,9 @@ The authors of this program may be contacted at http://forum.princed.org
 
 #include "common.h"
 #include <time.h>
+#ifndef _MSC_VER // unistd.h does not exist in the Windows SDK.
 #include <unistd.h>
+#endif
 #include <sys/stat.h>
 
 // Directory listing using dirent.h is available using MinGW on Windows, but not using MSVC (need to use Win32 API).

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -20,7 +20,9 @@ The authors of this program may be contacted at http://forum.princed.org
 
 #include "common.h"
 #include <fcntl.h>
+#ifndef _MSC_VER // unistd.h does not exist in the Windows SDK.
 #include <unistd.h>
+#endif
 #include <setjmp.h>
 #include <math.h>
 

--- a/src/seg001.c
+++ b/src/seg001.c
@@ -19,7 +19,10 @@ The authors of this program may be contacted at http://forum.princed.org
 */
 
 #include "common.h"
+
+#ifndef _MSC_VER // unistd.h does not exist in the Windows SDK.
 #include <unistd.h>
+#endif
 #include <fcntl.h>
 
 // data:4CB4


### PR DESCRIPTION
* Point to SDL 2.0.6 library files
* Fixed compiling with MSVC (cl.exe cannot find the unistd.h header)
* build.bat: use /subsystem:windows,5.01 for compatibility with XP; faster compilation by using the /MP flag (use parallelism on multi-core machines); print a better message to the console, if the build failed.