### PR TITLE
Use 8-bit audio samples if linking against older SDL2 versions

### DIFF
--- a/src/seg009.c
+++ b/src/seg009.c
@@ -1613,11 +1613,25 @@ void init_digi() {
 	if (digi_audiospec != NULL) return;
 	// Open the audio device. Called once.
 	//printf("init_digi(): called\n");
-	SDL_AudioSpec *desired;
+
+    SDL_AudioFormat desired_audioformat;
+    SDL_version version;
+    SDL_GetVersion(&version);
+    //printf("SDL Version = %d.%d.%d\n", version.major, version.minor, version.patch);
+    if (version.major <= 2 && version.minor <= 0 && version.patch <= 3) {
+        // In versions before 2.0.4, 16-bit audio samples don't work properly (the sound becomes garbled).
+        // See: https://bugzilla.libsdl.org/show_bug.cgi?id=2389
+        // Workaround: set the audio format to 8-bit, if we are linking against an older SDL2 version.
+        desired_audioformat = AUDIO_U8;
+    } else {
+        desired_audioformat = AUDIO_S16SYS;
+    }
+
+    SDL_AudioSpec *desired;
 	desired = (SDL_AudioSpec *)malloc(sizeof(SDL_AudioSpec));
 	memset(desired, 0, sizeof(SDL_AudioSpec));
 	desired->freq = digi_samplerate; //buffer->digi.sample_rate;
-	desired->format = AUDIO_S16SYS;
+	desired->format = desired_audioformat;
 	desired->channels = 2;
 	desired->samples = 1024;
 #ifndef USE_MIXER


### PR DESCRIPTION
Detect if the SDL2 version is 2.0.3 or older, and if so, circumvent the audio garbling that occurs with 16 bit audio samples.

See issue: #137