### PR TITLE
Add SDL_Joystick interface because not all joysticks are SDL_Controller compatible

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -215,4 +215,10 @@ The authors of this program may be contacted at http://forum.princed.org
 // Useful if SDL detected a gamepad but there is none.
 #define USE_AUTO_INPUT_MODE
 
+// Default SDL_Joystick button values
+#define SDL_JOYSTICK_BUTTON_Y 2
+#define SDL_JOYSTICK_BUTTON_X 3
+#define SDL_JOYSTICK_X_AXIS 0
+#define SDL_JOYSTICK_Y_AXIS 1
+
 #endif

--- a/src/data.h
+++ b/src/data.h
@@ -566,6 +566,7 @@ extern SDL_Window* window_;
 extern SDL_Texture* sdl_texture_;
 
 extern SDL_GameController* sdl_controller_ INIT( = 0 );
+extern SDL_Joystick* sdl_joystick_ INIT( = 0 ); // in case our joystick is not compatible with SDL_GameController
 extern int joy_axis[6]; // hor/ver axes for left/right sticks + left and right triggers (in total 6 axes)
 extern int joy_left_stick_states[2]; // horizontal, vertical
 extern int joy_right_stick_states[2];


### PR DESCRIPTION
Hi David:

I have added back SDL_Joystick interface code, because not all joysticks are compatible with the SDL_GameController interface. For example, my PS1 original pads are not compatible with SDL_GameController, and several wired USB joysticks I have around are also incompatible.
So here is the fix.