### PR TITLE
Fix SDL_Joystick interfering with SDL_GameController interface

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -49,6 +49,9 @@ enable_controller_rumble = true
 ; This could make the game easier to control, depending on your preference and depending on which controller you have.
 joystick_only_horizontal = true
 
+; Joystick 'dead zone' sensitivity threshold. Range: 0 to 32767 (default = 8000)
+joystick_threshold = 8000
+
 ; You can choose which levels to play using the 'levelset' option:
 ;    'original'       --> play the original levels (Default)
 ;    'Your Mod Name'  --> play a custom levelset (the custom files must be in a directory "mods/Your Mod Name/")

--- a/src/config.h
+++ b/src/config.h
@@ -33,8 +33,6 @@ The authors of this program may be contacted at http://forum.princed.org
 #define SDLPOP_VERSION "1.17"
 #define WINDOW_TITLE "Prince of Persia (SDLPoP) v" SDLPOP_VERSION
 
-#define JOY_THRESHOLD 8000
-
 // Enable or disable fading.
 // Fading used to be very buggy, but now it works correctly.
 #define USE_FADE

--- a/src/data.h
+++ b/src/data.h
@@ -652,6 +652,7 @@ extern byte enable_text INIT(= 1);
 extern byte enable_info_screen INIT(= 1);
 extern byte enable_controller_rumble INIT(= 0);
 extern byte joystick_only_horizontal INIT(= 0);
+extern int joystick_threshold INIT(= 8000);
 extern byte enable_quicksave INIT(= 1);
 extern byte enable_quicksave_penalty INIT(= 1);
 extern byte enable_replay INIT(= 1);

--- a/src/data.h
+++ b/src/data.h
@@ -566,7 +566,8 @@ extern SDL_Window* window_;
 extern SDL_Texture* sdl_texture_;
 
 extern SDL_GameController* sdl_controller_ INIT( = 0 );
-extern SDL_Joystick* sdl_joystick_ INIT( = 0 ); // in case our joystick is not compatible with SDL_GameController
+extern SDL_Joystick* sdl_joystick_; // in case our joystick is not compatible with SDL_GameController
+extern byte using_sdl_joystick_interface;
 extern int joy_axis[6]; // hor/ver axes for left/right sticks + left and right triggers (in total 6 axes)
 extern int joy_left_stick_states[2]; // horizontal, vertical
 extern int joy_right_stick_states[2];

--- a/src/options.c
+++ b/src/options.c
@@ -144,38 +144,21 @@ static inline int ini_process_boolean(const char* curr_name, const char* value, 
 	return 0; // not the right option; should check another option_name
 }
 
-static inline int ini_process_word(const char* curr_name, const char* value, const char* option_name, word* target, ini_value_list_type* value_names) {
-	if(strcasecmp(curr_name, option_name) == 0) {
-		if (strcasecmp(value, "default") != 0) {
-			int named_value = ini_get_named_value(value, value_names);
-			*target = (named_value == INI_NO_VALID_NAME) ? ((word) strtoumax(value, NULL, 0)) : ((word) named_value);
-		}
-		return 1; // finished; don't look for more possible options that curr_name can be
-	}
-	return 0; // not the right option; should check another option_name
+#define ini_process_numeric_func(data_type) \
+static inline int ini_process_##data_type(const char* curr_name, const char* value, const char* option_name, data_type* target, ini_value_list_type* value_names) { \
+	if(strcasecmp(curr_name, option_name) == 0) { \
+		if (strcasecmp(value, "default") != 0) { \
+			int named_value = ini_get_named_value(value, value_names); \
+			*target = (named_value == INI_NO_VALID_NAME) ? ((data_type) strtoimax(value, NULL, 0)) : ((data_type) named_value); \
+		} \
+		return 1; /* finished; don't look for more possible options that curr_name can be */ \
+	} \
+	return 0; /* not the right option; should check another option_name */ \
 }
-
-static inline int ini_process_short(const char* curr_name, const char* value, const char* option_name, short* target, ini_value_list_type* value_names) {
-	if(strcasecmp(curr_name, option_name) == 0) {
-		if (strcasecmp(value, "default") != 0) {
-			int named_value = ini_get_named_value(value, value_names);
-			*target = (named_value == INI_NO_VALID_NAME) ? ((short) strtoimax(value, NULL, 0)) : ((short) named_value);
-		}
-		return 1; // finished; don't look for more possible options that curr_name can be
-	}
-	return 0; // not the right option; should check another option_name
-}
-
-static inline int ini_process_byte(const char* curr_name, const char* value, const char* option_name, byte* target, ini_value_list_type* value_names) {
-	if(strcasecmp(curr_name, option_name) == 0) {
-		if (strcasecmp(value, "default") != 0) {
-			int named_value = ini_get_named_value(value, value_names);
-			*target = (named_value == INI_NO_VALID_NAME) ? ((byte) strtoumax(value, NULL, 0)) : ((byte) named_value);
-		}
-		return 1; // finished; don't look for more possible options that curr_name can be
-	}
-	return 0; // not the right option; should check another option_name
-}
+ini_process_numeric_func(word)
+ini_process_numeric_func(short)
+ini_process_numeric_func(byte)
+ini_process_numeric_func(int)
 
 static int global_ini_callback(const char *section, const char *name, const char *value)
 {
@@ -193,6 +176,9 @@ static int global_ini_callback(const char *section, const char *name, const char
 	#define process_byte(option_name, target, value_names)                           \
 	if (ini_process_byte(name, value, option_name, target, value_names)) return 1;
 
+	#define process_int(option_name, target, value_names)                           \
+	if (ini_process_int(name, value, option_name, target, value_names)) return 1;
+
 	#define process_boolean(option_name, target)                        \
 	if (ini_process_boolean(name, value, option_name, target)) return 1;
 
@@ -209,6 +195,7 @@ static int global_ini_callback(const char *section, const char *name, const char
 		process_boolean("use_correct_aspect_ratio", &use_correct_aspect_ratio);
 		process_boolean("enable_controller_rumble", &enable_controller_rumble);
 		process_boolean("joystick_only_horizontal", &joystick_only_horizontal);
+		process_int("joystick_threshold", &joystick_threshold, NULL);
 
 		if (strcasecmp(name, "levelset") == 0) {
 			if (value[0] == '\0' || strcasecmp(value, "original") == 0 || strcasecmp(value, "default") == 0) {

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -1178,7 +1178,7 @@ void get_joystick_state(int raw_x, int raw_y, int axis_state[2]) {
 
 	// check if the X/Y position is within the 'dead zone' of the joystick
 	int dist_squared = raw_x*raw_x + raw_y*raw_y;
-	if (dist_squared < JOY_THRESHOLD*JOY_THRESHOLD) {
+	if (dist_squared < joystick_threshold*joystick_threshold) {
 		axis_state[0] = 0;
 		axis_state[1] = 0;
 	} else {
@@ -1221,9 +1221,9 @@ void get_joystick_state(int raw_x, int raw_y, int axis_state[2]) {
 }
 
 void get_joystick_state_hor_only(int raw_x, int axis_state[2]) {
-	if (raw_x > JOY_THRESHOLD) {
+	if (raw_x > joystick_threshold) {
 		axis_state[0] = 1;
-	} else if (raw_x < -JOY_THRESHOLD) {
+	} else if (raw_x < -joystick_threshold) {
 		axis_state[0] = -1;
 	} else axis_state[0] = 0;
 

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -624,6 +624,7 @@ int __pascal far set_joy_mode() {
 		else {
 			sdl_joystick_ = SDL_JoystickOpen(0);
 			is_joyst_mode = 1;
+			using_sdl_joystick_interface = 1;
 		}
 	}
 	if (enable_controller_rumble && is_joyst_mode) {
@@ -2759,6 +2760,11 @@ void idle() {
 				}
 				break;
 			case SDL_JOYBUTTONDOWN:
+				// Only handle the event if the joystick is incompatible with the SDL_GameController interface.
+				// (Otherwise it will interfere with the normal action of the SDL_GameController API.)
+				if (!using_sdl_joystick_interface) {
+					break;
+				}
 #ifdef USE_AUTO_INPUT_MODE
 				if (!is_joyst_mode) {
 					is_joyst_mode = 1;
@@ -2769,6 +2775,7 @@ void idle() {
 				{
 					case SDL_JOYSTICK_BUTTON_Y:            joy_AY_buttons_state = -1; break; /*** Y (up) ***/
 					case SDL_JOYSTICK_BUTTON_X:            joy_X_button_state = 1;    break; /*** X (shift) ***/
+					default: break;
 				}
 				break;
 			case SDL_JOYBUTTONUP:
@@ -2776,11 +2783,16 @@ void idle() {
 				{
 					case SDL_JOYSTICK_BUTTON_Y:            joy_AY_buttons_state = 0; break; /*** Y (up) ***/
 					case SDL_JOYSTICK_BUTTON_X:            joy_X_button_state = 0;   break; /*** X (shift) ***/
-					break;
+					default: break;
 
 				}
 				break;
 			case SDL_JOYAXISMOTION:
+				// Only handle the event if the joystick is incompatible with the SDL_GameController interface.
+                // (Otherwise it will interfere with the normal action of the SDL_GameController API.)
+                if (!using_sdl_joystick_interface) {
+                    break;
+                }
 #ifdef USE_AUTO_INPUT_MODE
 				if (!is_joyst_mode) {
 					is_joyst_mode = 1;


### PR DESCRIPTION
This should fix issue #144.
SDL_JOYBUTTONDOWN and SDL_JOYAXISMOTION events were handled, even though this is not necessary for controllers that work with the SDL_GameController interface. This caused strange behavior for those controllers (at least for the Xbox 360 controller, which I used to test this).