### PR TITLE
Locate data files if they are missing in the working directory

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -34,6 +34,16 @@ extern "C" {
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifndef _MSC_VER // unistd.h does not exist in the Windows SDK.
+#include <unistd.h>
+#else
+#ifndef _UNISTD_H
+#define _UNISTD_H    1
+#define F_OK    0       /* Test for existence.  */
+#define access _access
+#endif
+#endif
+
 #include "config.h"
 #include "types.h"
 #include "proto.h"

--- a/src/options.c
+++ b/src/options.c
@@ -359,7 +359,7 @@ static int mod_ini_callback(const char *section, const char *name, const char *v
 }
 
 void load_global_options() {
-	ini_load("SDLPoP.ini", global_ini_callback); // global configuration
+	ini_load(locate_file("SDLPoP.ini"), global_ini_callback); // global configuration
 }
 
 void check_mod_param() {

--- a/src/proto.h
+++ b/src/proto.h
@@ -510,6 +510,8 @@ image_type* get_image(short chtab_id, int id);
 
 // SEG009.C
 void sdlperror(const char* header);
+#define locate_file(filename) locate_file_(filename, alloca(POP_MAX_PATH), POP_MAX_PATH)
+const char* locate_file_(const char* filename, char* path_buffer, int buffer_size);
 int __pascal far read_key();
 void __pascal far clear_kbd_buf();
 word __pascal far prandom(word max);

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -19,10 +19,6 @@ The authors of this program may be contacted at http://forum.princed.org
 */
 
 #include "common.h"
-#include <fcntl.h>
-#ifndef _MSC_VER // unistd.h does not exist in the Windows SDK.
-#include <unistd.h>
-#endif
 #include <setjmp.h>
 #include <math.h>
 

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -19,10 +19,7 @@ The authors of this program may be contacted at http://forum.princed.org
 */
 
 #include "common.h"
-#include <fcntl.h>
-#include <stdlib.h>
 #include <time.h>
-#include <sys/stat.h>
 #include <errno.h>
 
 // Most functions in this file are different from those in the original game.
@@ -32,6 +29,43 @@ void sdlperror(const char* header) {
 	printf("%s: %s\n",header,error);
 	//quit(1);
 }
+
+char exe_dir[POP_MAX_PATH] = ".";
+bool found_exe_dir = false;
+
+void find_exe_dir() {
+	if (found_exe_dir) return;
+	strncpy(exe_dir, g_argv[0], sizeof(exe_dir));
+	char* last_slash = NULL;
+	char* pos = exe_dir;
+	for (char c = *pos; c != '\0'; c = *(++pos)) {
+		if (c == '/' || c == '\\') {
+			last_slash = pos;
+		}
+	}
+	if (last_slash != NULL) {
+		*last_slash = '\0';
+	}
+	found_exe_dir = true;
+}
+
+static inline bool file_exists(const char* filename) {
+    return (access(filename, F_OK) != -1);
+}
+
+const char* locate_file_(const char* filename, char* path_buffer, int buffer_size) {
+	if(file_exists(filename)) {
+		return filename;
+	} else {
+		// If failed, it may be that SDLPoP is being run from the wrong different working directory.
+		// We can try to rescue the situation by loading from the directory of the executable.
+		find_exe_dir();
+        snprintf(path_buffer, buffer_size, "%s/%s", exe_dir, filename);
+        return (const char*) path_buffer;
+	}
+}
+
+
 
 dat_type* dat_chain_ptr = NULL;
 
@@ -158,6 +192,11 @@ static FILE* open_dat_from_root_or_data_dir(const char* filename) {
 	if (fp == NULL) {
 		char data_path[POP_MAX_PATH];
 		snprintf(data_path, sizeof(data_path), "data/%s", filename);
+
+        if (!file_exists(data_path)) {
+            find_exe_dir();
+            snprintf(data_path, sizeof(data_path), "%s/data/%s", exe_dir, filename);
+        }
 
 		// verify that this is a regular file and not a directory (otherwise, don't open)
 		struct stat path_stat;
@@ -1673,7 +1712,7 @@ const int max_sound_id = 58;
 char** sound_names = NULL;
 
 void load_sound_names() {
-	const char* names_path = "data/music/names.txt";
+	const char* names_path = locate_file("data/music/names.txt");
 	if (sound_names != NULL) return;
 	FILE* fp = fopen(names_path,"rt");
 	if (fp==NULL) return;
@@ -1721,16 +1760,16 @@ sound_buffer_type* load_sound(int index) {
 			for (i = 0; i < COUNT(exts); ++i) {
 				char filename[POP_MAX_PATH];
 				const char* ext=exts[i];
-				struct stat info;
 
 				snprintf(filename, sizeof(filename), "data/music/%s.%s", sound_name(index), ext);
+                const char* located_filename = locate_file(filename);
 				// Skip nonexistent files:
-				if (stat(filename, &info))
+				if (!file_exists(located_filename))
 					continue;
 				//printf("Trying to load %s\n", filename);
-				Mix_Music* music = Mix_LoadMUS(filename);
+				Mix_Music* music = Mix_LoadMUS(located_filename);
 				if (music == NULL) {
-					sdlperror(filename);
+					sdlperror(located_filename);
 					//sdlperror("Mix_LoadWAV");
 					continue;
 				}
@@ -2014,7 +2053,7 @@ void __pascal far set_gr_mode(byte grmode) {
 	                           pop_window_width, pop_window_height, flags);
 	renderer_ = SDL_CreateRenderer(window_, -1 , SDL_RENDERER_ACCELERATED );
 
-	SDL_Surface* icon = IMG_Load("data/icon.png");
+	SDL_Surface* icon = IMG_Load(locate_file("data/icon.png"));
 	if (icon == NULL) {
 		sdlperror("Could not load icon");
 	} else {
@@ -2168,16 +2207,16 @@ void load_from_opendats_metadata(int resource_id, const char* extension, FILE** 
 			snprintf(image_filename,sizeof(image_filename),"data/%s/res%d.%s",filename_no_ext, resource_id, extension);
 			if (!use_custom_levelset) {
 				//printf("loading (binary) %s",image_filename);
-				fp = fopen(image_filename, "rb");
+				fp = fopen(locate_file(image_filename), "rb");
 			}
 			else {
 				char image_filename_mod[POP_MAX_PATH];
 				// before checking data/, first try mods/MODNAME/data/
 				snprintf(image_filename_mod, sizeof(image_filename_mod), "mods/%s/%s", levelset_name, image_filename);
 				//printf("loading (binary) %s",image_filename_mod);
-				fp = fopen(image_filename_mod, "rb");
+				fp = fopen(locate_file(image_filename_mod), "rb");
 				if (fp == NULL) {
-					fp = fopen(image_filename, "rb");
+					fp = fopen(locate_file(image_filename), "rb");
 				}
 			}
 

--- a/src/unistd_win.h
+++ b/src/unistd_win.h
@@ -1,9 +1,0 @@
-#pragma once
-#ifndef _UNISTD_H
-#define _UNISTD_H    1
-
-#define F_OK    0       /* Test for existence.  */
-
-#define access _access
-
-#endif


### PR DESCRIPTION
This adds a fallback so that whenever SDLPoP cannot find some file in the current working directory, it can instead load from the folder where the executable lives. This makes it easier to run the game from another location (not having to worry about missing data files).

Also:
* Inlined `unistd_win.h` into `common.h`, as it is only a few lines long.
* Removed some import statements that were already in `common.h`
* Factored the code for checking if a file exists (`file_exists()` in `seg009.c`)