### PR TITLE
Pause menu cleanup; fix build.bat build script for MSVC

### DIFF
--- a/src/build.bat
+++ b/src/build.bat
@@ -40,14 +40,15 @@ if [%1]==[debug] goto build_type_debug
 if [%1]==[release] goto build_type_release
 echo Build type not specified, compiling in release mode...
 echo To specify the build type, run as "build.bat debug" or "build.bat release".
+goto build_type_release
 
 :build_type_debug
-set BuildTypeCompilerFlags= /MDd /Od
+set BuildTypeCompilerFlags= /MTd /Od /Z7
 set PreprocessorDefinitions= -DDEBUG=1
 goto compile
 
 :build_type_release
-set BuildTypeCompilerFlags= /MD /O2
+set BuildTypeCompilerFlags= /MT /O2
 set PreprocessorDefinitions=
 
 :compile
@@ -66,6 +67,9 @@ goto cleanup
 echo Output: ..\prince.exe
 
 :cleanup
-del icon.res
-del *.obj
-
+if [%1]==[debug] exit /b
+del icon.res 2> NUL
+del *.obj 2> NUL
+del ..\prince.exp 2> NUL
+del ..\prince.lib 2> NUL
+del ..\prince.pdb 2> NUL

--- a/src/data.h
+++ b/src/data.h
@@ -660,6 +660,7 @@ extern byte use_integer_scaling INIT(= 0);
 extern byte scaling_type INIT(= 0);
 #ifdef USE_LIGHTING
 extern byte enable_lighting INIT(= 0);
+extern image_type* lighting_mask;
 #endif
 extern fixes_options_type fixes_saved;
 extern fixes_options_type fixes_disabled_state;
@@ -709,10 +710,12 @@ extern byte is_timer_displayed INIT(= 0);
 
 #ifdef USE_MENU
 extern font_type hc_small_font INIT(= {32, 126, 5, 2, 1, 1, NULL});
-extern bool mouse_state_changed;
+extern bool have_mouse_input;
+extern bool have_keyboard_or_controller_input;
 extern int mouse_x, mouse_y;
+extern bool mouse_moved;
 extern bool mouse_clicked;
-extern bool clicked_or_pressed_enter;
+extern bool mouse_button_clicked_right;
 extern bool pressed_enter;
 extern bool escape_key_suppressed;
 extern int menu_control_scroll_y;

--- a/src/lighting.c
+++ b/src/lighting.c
@@ -22,7 +22,6 @@ The authors of this program may be contacted at http://forum.princed.org
 
 #ifdef USE_LIGHTING
 
-image_type* lighting_mask = NULL;
 image_type* screen_overlay = NULL;
 Uint32 bgcolor;
 

--- a/src/options.c
+++ b/src/options.c
@@ -74,9 +74,9 @@ int ini_load(const char *filename,
 	return 0;
 }
 
-NAME_LIST(level_type_names, {"dungeon", "palace"});
-NAME_LIST(guard_type_names, {"guard", "fat", "skel", "vizier", "shadow"});
-NAME_LIST(tile_type_names, {
+NAMES_LIST(level_type_names, {"dungeon", "palace"});
+NAMES_LIST(guard_type_names, {"guard", "fat", "skel", "vizier", "shadow"});
+NAMES_LIST(tile_type_names, {
 				"empty", "floor", "spike", "pillar", "gate",                                        // 0..4
 				"stuck", "closer", "doortop_with_floor", "bigpillar_bottom", "bigpillar_top",       // 5..9
 				"potion", "loose", "doortop", "mirror", "debris",                                   // 10..14
@@ -85,7 +85,7 @@ NAME_LIST(tile_type_names, {
 				"lattice_pillar", "lattice_down", "lattice_small", "lattice_left", "lattice_right", // 25..29
 				"torch_with_debris", // 30
 });
-NAME_LIST(scaling_type_names, {"sharp", "fuzzy", "blurry"});
+NAMES_LIST(scaling_type_names, {"sharp", "fuzzy", "blurry"});
 
 #define INI_NO_VALID_NAME (-9999)
 

--- a/src/proto.h
+++ b/src/proto.h
@@ -674,6 +674,7 @@ void init_menu();
 void menu_scroll(int y);
 void draw_menu();
 void clear_menu_controls();
+void process_additional_menu_input();
 int key_test_paused_menu(int key);
 void load_ingame_settings();
 void menu_was_closed();

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -52,6 +52,7 @@ void far pop_main() {
 	#endif
 
 	load_global_options();
+	check_mod_param();
 #ifdef USE_MENU
 	load_ingame_settings();
 #endif
@@ -73,7 +74,6 @@ void far pop_main() {
 	}
 #endif
 
-	check_mod_param();
 	load_mod_options();
 
 	// CusPop option

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -2774,9 +2774,11 @@ void toggle_fullscreen() {
 	uint32_t flags = SDL_GetWindowFlags(window_);
 	if (flags & SDL_WINDOW_FULLSCREEN_DESKTOP) {
 		SDL_SetWindowFullscreen(window_, 0);
+		SDL_ShowCursor(SDL_ENABLE);
 	}
 	else {
 		SDL_SetWindowFullscreen(window_, SDL_WINDOW_FULLSCREEN_DESKTOP);
+		SDL_ShowCursor(SDL_DISABLE);
 	}
 }
 
@@ -3029,12 +3031,21 @@ void process_events() {
 				break;
 #ifdef USE_MENU
 			case SDL_MOUSEBUTTONDOWN:
-				if (!is_menu_shown) {
-					last_key_scancode = SDL_SCANCODE_BACKSPACE;
-				} else {
-					mouse_clicked = true;
-					clicked_or_pressed_enter = true;
+				switch(event.button.button) {
+					case SDL_BUTTON_LEFT:
+						if (!is_menu_shown) {
+							last_key_scancode = SDL_SCANCODE_BACKSPACE;
+						} else {
+							mouse_clicked = true;
+						}
+						break;
+					case SDL_BUTTON_RIGHT:
+					case SDL_BUTTON_X1: // 'Back' button (on mice that have these extra buttons).
+						mouse_button_clicked_right = true;
+						break;
+					default: break;
 				}
+
 				break;
 			case SDL_MOUSEWHEEL:
 				if (is_menu_shown) {

--- a/src/types.h
+++ b/src/types.h
@@ -1058,7 +1058,7 @@ typedef struct names_list_type {
 } names_list_type;
 
 // Macro for declaring and initializing a names_list_type.
-#define NAME_LIST(listname, ...) const char listname[][MAX_OPTION_VALUE_NAME_LENGTH] = __VA_ARGS__; \
+#define NAMES_LIST(listname, ...) const char listname[][MAX_OPTION_VALUE_NAME_LENGTH] = __VA_ARGS__; \
 names_list_type listname##_list = {&listname, COUNT(listname)}
 
 #pragma pack(push,1)


### PR DESCRIPTION
Pause menu:
* Fixed settings from custom levelsets potentially carrying over when switching levelsets. (Split settings into 'user-managed' and 'mod-managed'. When switching to a different mod, all 'mod-managed' settings get reset. The levelset name is now also stored in SDLPoP.cfg, so that we can check whether we switched to a different mod.)
* Fixed a few minor drawing bugs in the pause menu.
* In fullscreen mode, only show the mouse cursor when necessary (when the menu is shown, and when not using keyboard or controller instead).
* Can now use right mouse button (or the 'back'/'X1' mouse button) to close menus.
* Fixed a controller hold-down delay bug, which caused the A and B buttons to be ignored if they are pressed immediately after letting go of the held-down button.
* General code cleanup for the pause menu.
* Renamed NAME_LIST() macro to NAMES_LIST() for consistency with the struct names_list_type.

build.bat:
* Link the CRT statically instead of dynamically (compiler option "/MT" instead of "/MD").
* Fixed build type defaulting to debug, not release, if no parameter is passed to build.bat.
* Fixed debugging using the MSVC debugger (added /Z7 flag, fixed files needed for debugging being deleted at cleanup).