### PR TITLE
Allow changing the mods folder

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -80,6 +80,8 @@ joystick_threshold = 8000
 
 levelset = original
 
+; The base directory where SDLPoP will look for custom levelsets. (default = mods)
+mods_folder = mods
 
 
 [AdditionalFeatures]

--- a/doc/ChangeLog.txt
+++ b/doc/ChangeLog.txt
@@ -492,3 +492,4 @@ DONE: Added in-game menu (press Escape or Backspace) with ability to change sett
 CHANGE: Removed the startup prompt to enable or disable fixes/enhancements (no longer needed).
 FIXED: Fixed turning off music not working.
 DONE: Added option for disabling and enabling all customization options at once.
+DONE: Added option for changing the mods directory (where the game looks for custom levelsets).

--- a/src/data.h
+++ b/src/data.h
@@ -718,6 +718,7 @@ extern bool escape_key_suppressed;
 extern int menu_control_scroll_y;
 extern sbyte is_menu_shown;
 extern byte enable_pause_menu INIT(= 1);
+extern char mods_folder[POP_MAX_PATH] INIT(= "mods");
 #endif
 
 #undef INIT

--- a/src/options.c
+++ b/src/options.c
@@ -151,6 +151,12 @@ static int global_ini_callback(const char *section, const char *name, const char
 	if (check_ini_section("General")) {
 #ifdef USE_MENU
 		process_boolean("enable_pause_menu", &enable_pause_menu);
+		if (strcasecmp(name, "mods_folder") == 0) {
+			if (value[0] != '\0' && strcasecmp(value, "default") != 0) {
+				strcpy(mods_folder, locate_file(value));
+			}
+			return 1;
+		}
 #endif
 		process_boolean("enable_copyprot", &enable_copyprot);
 		process_boolean("enable_mixer", &enable_mixer);
@@ -188,7 +194,7 @@ static int global_ini_callback(const char *section, const char *name, const char
 
 		if (strcasecmp(name, "replays_folder") == 0) {
 			if (value[0] != '\0' && strcasecmp(value, "default") != 0) {
-				strcpy(replays_folder, value);
+				strcpy(replays_folder, locate_file(value));
 			}
 			return 1;
 		}
@@ -366,6 +372,7 @@ void load_global_options() {
 void check_mod_param() {
 	// The 'mod' command line argument can override the levelset choice in SDLPoP.ini
 	// usage: prince mod "Mod Name"
+	// TODO: maybe allow absolute paths, instead of only paths relative to the mods folder?
 	const char* mod_param = check_param("mod");
 	if (mod_param != NULL) {
 		use_custom_levelset = true;
@@ -378,13 +385,13 @@ void load_mod_options() {
 	// load mod-specific INI configuration
 	if (use_custom_levelset) {
 		char filename[POP_MAX_PATH];
-		snprintf(filename, sizeof(filename), "mods/%s/%s", levelset_name, "mod.ini");
+		snprintf(filename, sizeof(filename), "%s/%s/%s", mods_folder, levelset_name, "mod.ini");
 		const char* located_filename = locate_file(filename);
 		if (file_exists(located_filename)) {
 			// Nearly all mods would want to use custom options, so always allow them.
 			// TODO: Prevent mod settings and user settings from interfering with each other.
 			use_custom_options = 1;
-			ini_load(filename, mod_ini_callback);
+			ini_load(located_filename, mod_ini_callback);
 		}
 		delay_ticks(1);
 	}

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -337,7 +337,7 @@ const char* get_quick_path(char* custom_path_buffer, size_t max_len) {
 		return quick_file;
 	}
 	// if playing a custom levelset, try to use the mod folder
-	snprintf(custom_path_buffer, max_len, "mods/%s/%s", levelset_name, quick_file /*QUICKSAVE.SAV*/ );
+	snprintf(custom_path_buffer, max_len, "%s/%s/%s", mods_folder, levelset_name, quick_file /*QUICKSAVE.SAV*/ );
 	return custom_path_buffer;
 }
 
@@ -1803,7 +1803,7 @@ const char* get_save_path(char* custom_path_buffer, size_t max_len) {
 		return save_file;
 	}
 	// if playing a custom levelset, try to use the mod folder
-	snprintf(custom_path_buffer, max_len, "mods/%s/%s", levelset_name, save_file /*PRINCE.SAV*/ );
+	snprintf(custom_path_buffer, max_len, "%s/%s/%s", mods_folder, levelset_name, save_file /*PRINCE.SAV*/ );
 	return custom_path_buffer;
 }
 

--- a/src/seg001.c
+++ b/src/seg001.c
@@ -767,7 +767,7 @@ const char* get_hof_path(char* custom_path_buffer, size_t max_len) {
 		return hof_file;
 	}
 	// if playing a custom levelset, try to use the mod folder
-	snprintf(custom_path_buffer, max_len, "mods/%s/%s", levelset_name, hof_file /*PRINCE.HOF*/ );
+	snprintf(custom_path_buffer, max_len, "%s/%s/%s", mods_folder, levelset_name, hof_file /*PRINCE.HOF*/ );
 	return custom_path_buffer;
 }
 

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -219,7 +219,7 @@ dat_type *__pascal open_dat(const char *filename,int drive) {
 	else {
 		char filename_mod[POP_MAX_PATH];
 		// before checking the root directory, first try mods/MODNAME/
-		snprintf(filename_mod, sizeof(filename_mod), "mods/%s/%s", levelset_name, filename);
+		snprintf(filename_mod, sizeof(filename_mod), "%s/%s/%s", mods_folder, levelset_name, filename);
 		fp = fopen(filename_mod, "rb");
 		if (fp == NULL) {
 			fp = open_dat_from_root_or_data_dir(filename);
@@ -2357,7 +2357,7 @@ void load_from_opendats_metadata(int resource_id, const char* extension, FILE** 
 			else {
 				char image_filename_mod[POP_MAX_PATH];
 				// before checking data/, first try mods/MODNAME/data/
-				snprintf(image_filename_mod, sizeof(image_filename_mod), "mods/%s/%s", levelset_name, image_filename);
+				snprintf(image_filename_mod, sizeof(image_filename_mod), "%s/%s/%s", mods_folder, levelset_name, image_filename);
 				//printf("loading (binary) %s",image_filename_mod);
 				fp = fopen(locate_file(image_filename_mod), "rb");
 				if (fp == NULL) {


### PR DESCRIPTION
I thought it might be a good idea to let users change the mods folder, if they wish.

Somewhat related to this thread:
http://forum.princed.org/viewtopic.php?f=112&t=4160

* Added option for changing the mods folder, where the game looks for custom levelsets.
* Fixed mod.ini, and the mods and replays folders potentially not being found, if the game is run from an unexpected working directory.