### PR TITLE
Fix hidden floors in level 12 not appearing until after the flashing stops

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -207,6 +207,11 @@ fix_feather_interrupted_by_leveldoor = true
 ; Guards will often not reappear in another room if they have been pushed (partly or entirely) offscreen.
 fix_offscreen_guards_disappearing = true
 
+; While putting the sword away, if you press forward and down, and then release down, the kid will still duck.
+fix_move_after_sheathe = true
+
+; After uniting with the shadow in level 12, the hidden floors will not appear until after the flashing stops.
+fix_hidden_floors_during_flashing = true
 
 
 [CustomGameplay]

--- a/doc/ChangeLog.txt
+++ b/doc/ChangeLog.txt
@@ -492,3 +492,4 @@ DONE: Added in-game menu (press Escape or Backspace) with ability to change sett
 CHANGE: Removed the startup prompt to enable or disable fixes/enhancements (no longer needed).
 FIXED: Fixed turning off music not working.
 DONE: Added option for disabling and enabling all customization options at once.
+DONE: Added fix for hidden floors in level 12 not appearing until after the flashing stops.

--- a/src/config.h
+++ b/src/config.h
@@ -187,8 +187,11 @@ The authors of this program may be contacted at http://forum.princed.org
 // Guards will often not reappear in another room if they have been pushed (partly or entirely) offscreen.
 #define FIX_OFFSCREEN_GUARDS_DISAPPEARING
 
-// Controls do not get released properly when putting the sword away, leading to unintended movement.
+// While putting the sword away, if you press forward and down, and then release down, the kid will still duck.
 #define FIX_MOVE_AFTER_SHEATHE
+
+// After uniting with the shadow in level 12, the hidden floors will not appear until after the flashing stops.
+#define FIX_HIDDEN_FLOORS_DURING_FLASHING
 
 
 // Debug features:

--- a/src/menu.c
+++ b/src/menu.c
@@ -189,6 +189,8 @@ enum setting_ids {
 	SETTING_FIX_CHOMPERS_NOT_STARTING,
 	SETTING_FIX_FEATHER_INTERRUPTED_BY_LEVELDOOR,
 	SETTING_FIX_OFFSCREEN_GUARDS_DISAPPEARING,
+	SETTING_FIX_MOVE_AFTER_SHEATHE,
+	SETTING_FIX_HIDDEN_FLOORS_DURING_FLASHING,
 	SETTING_USE_CUSTOM_OPTIONS,
 	SETTING_START_MINUTES_LEFT,
 	SETTING_START_TICKS_LEFT,
@@ -446,6 +448,14 @@ setting_type gameplay_settings[] = {
 				.linked = &fixes_saved.fix_offscreen_guards_disappearing, .required = &use_fixes_and_enhancements,
 				.text = "Fix offscreen guards disappearing",
 				.explanation = "Guards will often not reappear in another room if they have been pushed (partly or entirely) offscreen."},
+		{.id = SETTING_FIX_MOVE_AFTER_SHEATHE, .style = SETTING_STYLE_TOGGLE,
+				.linked = &fixes_saved.fix_move_after_sheathe, .required = &use_fixes_and_enhancements,
+				.text = "Fix movement after sheathing",
+				.explanation = "While putting the sword away, if you press forward and down, and then release down, the kid will still duck."},
+		{.id = SETTING_FIX_HIDDEN_FLOORS_DURING_FLASHING, .style = SETTING_STYLE_TOGGLE,
+				.linked = &fixes_saved.fix_hidden_floors_during_flashing, .required = &use_fixes_and_enhancements,
+				.text = "Fix hidden floors during flashing",
+				.explanation = "After uniting with the shadow in level 12, the hidden floors will not appear until after the flashing stops."},
 };
 
 NAME_LIST(tile_type_setting_names, {

--- a/src/options.c
+++ b/src/options.c
@@ -237,6 +237,7 @@ static int global_ini_callback(const char *section, const char *name, const char
 		process_boolean("fix_feather_interrupted_by_leveldoor", &fixes_saved.fix_feather_interrupted_by_leveldoor);
 		process_boolean("fix_offscreen_guards_disappearing", &fixes_saved.fix_offscreen_guards_disappearing);
 		process_boolean("fix_move_after_sheathe", &fixes_saved.fix_move_after_sheathe);
+		process_boolean("fix_hidden_floors_during_flashing", &fixes_saved.fix_hidden_floors_during_flashing);
 	}
 
 	if (check_ini_section("CustomGameplay")) {

--- a/src/replay.c
+++ b/src/replay.c
@@ -490,6 +490,7 @@ void options_process_fixes(SDL_RWops* rw, rw_process_func_type process_func) {
 	process(fixes_options_replay.fix_feather_interrupted_by_leveldoor);
 	process(fixes_options_replay.fix_offscreen_guards_disappearing);
 	process(fixes_options_replay.fix_move_after_sheathe);
+	process(fixes_options_replay.fix_hidden_floors_during_flashing);
 }
 
 void options_process_custom_general(SDL_RWops* rw, rw_process_func_type process_func) {

--- a/src/seg006.c
+++ b/src/seg006.c
@@ -957,7 +957,11 @@ void __pascal far check_on_floor() {
 		if (! tile_is_floor(curr_tile2)) {
 			// Special event: floors appear
 			if (current_level == 12 &&
+#ifndef FIX_HIDDEN_FLOORS_DURING_FLASHING
 				united_with_shadow < 0 &&
+#else
+				(united_with_shadow < 0 || (fixes->fix_hidden_floors_during_flashing && united_with_shadow > 0)) &&
+#endif
 				Char.curr_row == 0 &&
 				(Char.room == 2 || (Char.room == 13 && tile_col >= 6))
 			) {

--- a/src/types.h
+++ b/src/types.h
@@ -1095,6 +1095,7 @@ typedef struct fixes_options_type {
 	byte fix_feather_interrupted_by_leveldoor;
 	byte fix_offscreen_guards_disappearing;
 	byte fix_move_after_sheathe;
+	byte fix_hidden_floors_during_flashing;
 } fixes_options_type;
 
 typedef struct custom_options_type {


### PR DESCRIPTION
After uniting with the shadow in level 12, the hidden floors will not appear until after the flashing stops.
As mentioned by @EndeavourAccuracy here:
http://forum.princed.org/viewtopic.php?f=126&t=3512&p=22656#p22655

Also, fixed the 'move after sheathe' fix not being present in SDLPoP.ini and the menu. (I must have forgotten at the time... Sorry about that.) 
Changed the description for this fix as well, to be a bit more informative about what exactly is wrong.