### PR TITLE
Fix being able to open the menu during cutscenes

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -310,6 +310,7 @@ extern word demo_mode INIT(= 0);
 
 // data:42CA
 extern word is_cutscene;
+extern bool is_ending_sequence; // added
 
 // data:0FA0
 extern cutscene_ptr_type tbl_cutscenes[16] INIT(= {

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -536,7 +536,13 @@ int __pascal far process_key() {
 		case SDL_SCANCODE_ESCAPE | WITH_SHIFT: // allow pause while grabbing
 			is_paused = 1;
 #ifdef USE_MENU
-			if (enable_pause_menu) {
+			if (enable_pause_menu && !is_cutscene && !is_ending_sequence) {
+				is_menu_shown = 1;
+			}
+		break;
+		case SDL_SCANCODE_BACKSPACE:
+			if (!is_cutscene && !is_ending_sequence) {
+				is_paused = 1;
 				is_menu_shown = 1;
 			}
 #endif
@@ -651,12 +657,6 @@ int __pascal far process_key() {
 		break;
 #endif // USE_REPLAY
 #endif // USE_QUICKSAVE
-#ifdef USE_MENU
-		case SDL_SCANCODE_BACKSPACE:
-			is_paused = 1;
-			is_menu_shown = 1;
-		break;
-#endif
 	}
 	if (cheats_enabled) {
 		switch (key) {
@@ -1481,6 +1481,9 @@ int __pascal far do_paused() {
 		read_keyb_control();
 	}
 	key = process_key();
+	if (is_ending_sequence && is_paused) {
+		is_paused = 0; // fix being able to pause the game during the ending sequence
+	}
 	if (is_paused) {
 		display_text_bottom("GAME PAUSED");
 #ifdef USE_MENU
@@ -1875,6 +1878,7 @@ void __pascal far clear_screen_and_sounds() {
 	current_target_surface = rect_sthg(onscreen_surface_, &screen_rect);
 
 	is_cutscene = 0;
+	is_ending_sequence = false; // added
 	peels_count = 0;
 	// should these be freed?
 	for (index = 2; index < 10; ++index) {

--- a/src/seg001.c
+++ b/src/seg001.c
@@ -582,6 +582,7 @@ void __pascal far end_sequence() {
 	bgcolor = 15;
 	load_intro(1, &end_sequence_anim, 1);
 	clear_screen_and_sounds();
+	is_ending_sequence = true; // added (fix being able to pause the game during the end sequence)
 	load_opt_sounds(sound_56_ending_music, sound_56_ending_music); // winning theme
 	play_sound_from_buffer(sound_pointers[sound_56_ending_music]); // winning theme
 	if(offscreen_surface) free_surface(offscreen_surface); // missing in original
@@ -639,6 +640,7 @@ void __pascal far end_sequence() {
 	}
 	fade_out_2(0x1000);
 	start_level = -1;
+	is_ending_sequence = false;
 	start_game();
 }
 

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -2199,7 +2199,8 @@ void draw_overlay() {
 	if (is_timer_displayed && start_level > 0) overlay = 1; // Timer overlay
 #endif
 #ifdef USE_MENU
-	if (is_menu_shown) overlay = 2; // Menu overlay - not drawn here directly, only copied from the overlay surface.
+	// Menu overlay - not drawn here directly, only copied from the overlay surface.
+	if (is_paused && is_menu_shown) overlay = 2;
 #endif
 	if (overlay != 0) {
 		is_overlay_displayed = true;
@@ -2839,6 +2840,8 @@ void process_events() {
 						case SDL_SCANCODE_NUMLOCKCLEAR:
 						case SDL_SCANCODE_APPLICATION:
 						case SDL_SCANCODE_PRINTSCREEN:
+						case SDL_SCANCODE_VOLUMEUP:
+						case SDL_SCANCODE_VOLUMEDOWN:
 						case SDL_SCANCODE_PAUSE:
 							break;
 						default:


### PR DESCRIPTION
Also, during the ending/HOF sequence.
(Actually, being able to pause during the ending sequence is a bug in the DOS version. If you press Esc during the embrace cutscene, the screen stays black after the fadeout. Pressing Esc repeatedly after that advances the animation frame by frame.)

Also, the two changes in seg009.c:
* Fix rare case where the overlay surface contents may be drawn even though the game is unpaused.
* Fix volume up/down buttons (on keyboards that have them) causing the game to start during the title sequence.