### PR TITLE
Fuzzy pixels optimization: do nearest-neighbor upscaling on the GPU

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -549,6 +549,7 @@ extern SDL_Surface* onscreen_surface_;
 extern SDL_Surface* overlay_surface;
 extern SDL_Surface* merged_surface;
 extern SDL_Renderer* renderer_;
+extern bool is_renderer_targettexture_supported;
 extern SDL_Window* window_;
 extern bool is_overlay_displayed;
 extern SDL_Texture* texture_sharp;


### PR DESCRIPTION
Also commented out the update_screen() in set_bg_attr() to save a screen update. (Which gave a noticable delay on the Raspberry Pi with fuzzy pixels turned on)