### PR TITLE
More small fixes

### DIFF
--- a/src/lighting.c
+++ b/src/lighting.c
@@ -32,7 +32,7 @@ const Uint8 ambient_level = 128;
 void init_lighting() {
 	if (!enable_lighting) return;
 
-	lighting_mask = IMG_Load(mask_filename);
+	lighting_mask = IMG_Load(locate_file(mask_filename));
 	if (lighting_mask == NULL) {
 		sdlperror("IMG_Load (lighting_mask)");
 		enable_lighting = 0;

--- a/src/seg008.c
+++ b/src/seg008.c
@@ -1756,6 +1756,7 @@ void __pascal far show_time() {
 					// don't display time elapsed in the first minute
 					text_time_remaining = 0;
 					text_time_total = 0;
+					sprintf_temp[0] = '\0';
 				}
 				else if (~rem_min == 1) {
 					snprintf(sprintf_temp, sizeof(sprintf_temp), "1 MINUTE PASSED");


### PR DESCRIPTION
A few more minor bugs that I found:

* With infinite time enabled, garbage values are sometimes printed during the first minute. (Because sprintf_temp is uninitialized in show_time().)
* Torch lighting would not initialize when running from another working directory, because data/light.png could not be found.