### PR TITLE
Replace README.md by a symbolic link to doc/readme.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,1 @@
-# SDLPoP
-An open-source port of Prince of Persia, based on the disassembly of the DOS version.
-
-More info: doc/Readme.txt
+doc/Readme.txt

--- a/doc/Readme.txt
+++ b/doc/Readme.txt
@@ -1,3 +1,10 @@
+SDLPoP
+======
+
+An open-source port of Prince of Persia, based on the disassembly of the DOS version.
+
+---
+
 Name of program: SDLPoP
 (Earlier name: David's open-source port of PoP)
 


### PR DESCRIPTION
I did this to increase the visibility (on GitHub) of the readme located at `doc/readme.txt`