### PR TITLE
CMake: Don't link SDL2main on Linux

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,7 +114,9 @@ else()
 endif()
 
 if(WIN32)
-    target_link_libraries(prince mingw32 SDL2main SDL2 SDL2.dll SDL2_image)
-else()
+    target_link_libraries(prince mingw32 SDL2main SDL2 SDL2_image)
+elif(APPLE)
     target_link_libraries(prince SDL2main SDL2 SDL2_image m)
+else() # Linux, *BSD, etc.
+    target_link_libraries(prince SDL2 SDL2_image m)
 endif()


### PR DESCRIPTION
Also removed apparent duplicate `SDL2.dll` mention for `WIN32` (can revert if that's actually needed somehow, didn't try a mingw32 build to confirm).

A better fix would be to query `pkg-config --libs --cflags` to set things up properly (CMake has builtins for that), but as a quick yet correct fix this should work fine.

BTW, the `src/Makefile` generated by CMake overrides the existing one, it should maybe be renamed or removed if CMake is the main buildsystem.