### PR TITLE
Fix linker error when building with newer clang

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -117,7 +117,6 @@ int active_settings_subsection = 0;
 int highlighted_settings_subsection = 0;
 int scroll_position = 0;
 int menu_control_y;
-int menu_control_scroll_y;
 int menu_control_x;
 int menu_control_back;
 

--- a/src/seg001.c
+++ b/src/seg001.c
@@ -47,8 +47,6 @@ SDL_COMPILE_TIME_ASSERT(hof_size, sizeof(hof_type) == 29);
 #pragma pack(pop)
 
 #define MAX_HOF_COUNT 6
-// data:405E
-short hof_count;
 // data:589A
 hof_type hof[MAX_HOF_COUNT];
 

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -1943,7 +1943,6 @@ void init_digi() {
 
 const int sound_channel = 0;
 const int max_sound_id = 58;
-char** sound_names = NULL;
 
 void load_sound_names() {
 	const char* names_path = locate_file("data/music/names.txt");


### PR DESCRIPTION
The master branch of LLVM has a change that makes `-fno-common` a default for clang. This causes symbols with multiple definitions to become hard errors, which makes SDLPoP fail to link.

This PR fixes it by removing those second definitions - all removed symbols were already defined in `data.c`. It shouldn't introduce any behavioral changes, and I didn't notice any when I did a few minutes of gameplay testing.