### PR TITLE
Handle more error conditions and eliminate build warnings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -9,14 +9,16 @@ BIN = ../prince
 
 OS      := $(shell uname)
 
+CPPFLAGS += -Wall -D_GNU_SOURCE=1
+CFLAGS += -std=gnu99 -O2
+
 ifeq ($(OS),Darwin)
 LIBS := $(shell sdl2-config --libs) -lSDL2_image
-INCS := -I/opt/local/include
-CFLAGS += $(INCS) -Wall -std=gnu99 -D_GNU_SOURCE=1 -D_THREAD_SAFE -DOSX -O2
+CFLAGS += -I/opt/local/include
+CPPFLAGS += -D_THREAD_SAFE -DOSX
 else
 LIBS := $(shell pkg-config --libs   sdl2 SDL2_image)
-INCS := $(shell pkg-config --cflags sdl2 SDL2_image)
-CFLAGS += $(INCS) -Wall -std=gnu99 -O2
+CFLAGS += $(shell pkg-config --cflags sdl2 SDL2_image)
 endif
 
 all: $(BIN)
@@ -34,7 +36,7 @@ $(BIN): $(OBJ)
 	$(CC) $(LDFLAGS) $(OBJ) -o $@ $(LIBS) -lm
 
 %.o: %.c $(HFILES)
-	$(CC) $(CFLAGS) $(LDFLAGS) -c $<
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -c $<
 
 .PHONY: all clean
 

--- a/src/common.h
+++ b/src/common.h
@@ -25,7 +25,6 @@ The authors of this program may be contacted at https://forum.princed.org
 extern "C" {
 #endif
 
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <fcntl.h>
@@ -66,6 +65,15 @@ extern "C" {
 #ifndef ABS
 #define ABS(x) ((x)<0?-(x):(x))
 #endif
+
+#define snprintf_check(dst, size, ...)	do {			\
+		int __len;					\
+		__len = snprintf(dst, size, __VA_ARGS__);	\
+		if (__len < 0 || __len >= size) {		\
+			fprintf(stderr, "%s: buffer truncation detected!\n", __func__);\
+			quit(2);				\
+		}						\
+	} while (0)
 
 #ifdef __cplusplus
 }

--- a/src/data.h
+++ b/src/data.h
@@ -825,6 +825,42 @@ extern custom_options_type custom_defaults INIT(= {
 });
 extern custom_options_type* custom INIT(= &custom_defaults);
 
+extern full_image_type full_image[MAX_FULL_IMAGES] INIT(= {
+        [TITLE_MAIN] =     { .id = 0, .chtab = &chtab_title50,
+                             .blitter = blitters_0_no_transp,
+                             .xpos = 0, .ypos = 0 },
+        [TITLE_PRESENTS] = { .id = 1, .chtab = &chtab_title50,
+                             .blitter = blitters_0_no_transp,
+                             .xpos = 96, .ypos = 106 },
+        [TITLE_GAME] =     { .id = 2, .chtab = &chtab_title50,
+                             .blitter = blitters_0_no_transp,
+                             .xpos = 96, .ypos = 122 },
+        [TITLE_POP] =      { .id = 3, .chtab = &chtab_title50,
+                             .blitter = blitters_10h_transp,
+                             .xpos = 24, .ypos = 107 },
+        [TITLE_MECHNER] =  { .id = 4, .chtab = &chtab_title50,
+                             .blitter = blitters_0_no_transp,
+                             .xpos = 48, .ypos = 184 },
+        [HOF_POP] =        { .id = 3, .chtab = &chtab_title50,
+                             .blitter = blitters_10h_transp,
+                             .xpos = 24, .ypos = 24 },
+        [STORY_FRAME] =    { .id = 0, .chtab = &chtab_title40,
+                             .blitter = blitters_0_no_transp,
+                             .xpos = 0, .ypos = 0 },
+        [STORY_ABSENCE] =  { .id = 1, .chtab = &chtab_title40,
+                             .blitter = blitters_white,
+                             .xpos = 24, .ypos = 25 },
+        [STORY_MARRY] =    { .id = 2, .chtab = &chtab_title40,
+                             .blitter = blitters_white,
+                             .xpos = 24, .ypos = 25 },
+        [STORY_HAIL] =     { .id = 3, .chtab = &chtab_title40,
+                             .blitter = blitters_white,
+                             .xpos = 24, .ypos = 25 },
+        [STORY_CREDITS] =  { .id = 4, .chtab = &chtab_title40,
+                             .blitter = blitters_white,
+                             .xpos = 24, .ypos = 26 },
+});
+
 // data:009C
 extern word cheats_enabled INIT(= 0);
 #ifdef USE_DEBUG_CHEATS

--- a/src/menu.c
+++ b/src/menu.c
@@ -2043,12 +2043,16 @@ void calculate_exe_crc() {
 		FILE* exe_file = fopen(g_argv[0], "rb");
 		if (exe_file != NULL) {
 			fseek(exe_file, 0, SEEK_END);
-			int size = ftell(exe_file);
+			size_t size = ftell(exe_file);
 			fseek(exe_file, 0, SEEK_SET);
 			if (size > 0) {
-				byte* buffer = malloc((size_t)size);
-				fread(buffer, 1, (size_t)size, exe_file);
-				exe_crc = crc32c(buffer, (dword)size);
+				byte* buffer = malloc(size);
+				size_t bytes = fread(buffer, 1, size, exe_file);
+				if (bytes != size) {
+					fprintf(stderr, "exec changed size during CRC32!?\n");
+					size = bytes;
+				}
+				exe_crc = crc32c(buffer, size);
 				free(buffer);
 			}
 			fclose(exe_file);

--- a/src/options.c
+++ b/src/options.c
@@ -66,8 +66,12 @@ int ini_load(const char *filename,
 				*s = 0;
 			report(section, name, value);
 		}
-		fscanf(f, " ;%*[^\n]");
-		fscanf(f, " \n");
+		if (fscanf(f, " ;%*[^\n]") != 0 ||
+		    fscanf(f, " \n") != 0) {
+			fprintf(stderr, "short read from %s!?\n", filename);
+			fclose(f);
+			return -1;
+		}
 	}
 
 	fclose(f);
@@ -521,7 +525,11 @@ void load_dos_exe_modifications(const char* folder_name) {
 	if (dos_version >= 0) {
 		turn_custom_options_on_off(1);
 		byte* exe_memory = malloc((size_t) info.st_size);
-		fread(exe_memory, (size_t) info.st_size, 1, fp);
+		if (fread(exe_memory, (size_t) info.st_size, 1, fp) != 1) {
+			fprintf(stderr, "Could not read %s!?\n", filename);
+			fclose(fp);
+			return;
+		}
 
 		byte temp_bytes[64] = {0};
 		word temp_word = 0;

--- a/src/options.c
+++ b/src/options.c
@@ -452,7 +452,7 @@ void check_mod_param() {
 	if (mod_param != NULL) {
 		use_custom_levelset = true;
 		memset(levelset_name, 0, sizeof(levelset_name));
-		strncpy(levelset_name, mod_param, sizeof(levelset_name));
+		snprintf_check(levelset_name, sizeof(levelset_name), "%s", mod_param);
 	}
 }
 
@@ -677,7 +677,7 @@ void load_mod_options() {
 	if (use_custom_levelset) {
 		// find the folder containing the mod's files
 		char folder_name[POP_MAX_PATH];
-		snprintf(folder_name, sizeof(folder_name), "%s/%s", mods_folder, levelset_name);
+		snprintf_check(folder_name, sizeof(folder_name), "%s/%s", mods_folder, levelset_name);
 		const char* located_folder_name = locate_file(folder_name);
 		bool ok = false;
 		struct stat info;
@@ -685,12 +685,12 @@ void load_mod_options() {
 			if (S_ISDIR(info.st_mode)) {
 				// It's a directory
 				ok = true;
-				strncpy(mod_data_path, located_folder_name, sizeof(mod_data_path));
+				snprintf_check(mod_data_path, sizeof(mod_data_path), "%s", located_folder_name);
 				// Try to load PRINCE.EXE (DOS)
 				load_dos_exe_modifications(located_folder_name);
 				// Try to load mod.ini
 				char mod_ini_filename[POP_MAX_PATH];
-				snprintf(mod_ini_filename, sizeof(mod_ini_filename), "%s/%s", located_folder_name, "mod.ini");
+				snprintf_check(mod_ini_filename, sizeof(mod_ini_filename), "%s/%s", located_folder_name, "mod.ini");
 				if (file_exists(mod_ini_filename)) {
 					// Nearly all mods would want to use custom options, so always allow them.
 					use_custom_options = 1;

--- a/src/proto.h
+++ b/src/proto.h
@@ -59,7 +59,7 @@ void __pascal far gen_palace_wall_colors();
 void __pascal far show_title();
 void __pascal far transition_ltr();
 void __pascal far release_title_images();
-void __pascal far draw_image_2(int id,chtab_type* chtab_ptr,int xpos,int ypos,int blit);
+void __pascal far draw_full_image(enum full_image_id id);
 void __pascal far load_kid_sprite();
 void __pascal far save_game();
 short __pascal far load_game();

--- a/src/replay.c
+++ b/src/replay.c
@@ -89,7 +89,7 @@ int read_replay_header(replay_header_type* header, FILE* fp, char* error_message
 	fread(magic, 3, 1, fp);
 	if (strncmp(magic, replay_magic_number, 3) != 0) {
 		if (error_message != NULL) {
-			snprintf(error_message, REPLAY_HEADER_ERROR_MESSAGE_MAX, "not a valid replay file!");
+			snprintf_check(error_message, REPLAY_HEADER_ERROR_MESSAGE_MAX, "not a valid replay file!");
 		}
 		return 0; // incompatible, magic number not correct!
 	}
@@ -118,7 +118,7 @@ int read_replay_header(replay_header_type* header, FILE* fp, char* error_message
 	if (class != replay_format_class) {
 		// incompatible, replay format is associated with a different implementation of SDLPoP
 		if (error_message != NULL) {
-			snprintf(error_message, REPLAY_HEADER_ERROR_MESSAGE_MAX,
+			snprintf_check(error_message, REPLAY_HEADER_ERROR_MESSAGE_MAX,
 			         "replay created with \"%s\"...\nIncompatible replay class identifier! (expected %d, found %d)",
 			         header->implementation_name, replay_format_class, class);
 		}
@@ -128,7 +128,7 @@ int read_replay_header(replay_header_type* header, FILE* fp, char* error_message
 	if (version_number < REPLAY_FORMAT_MIN_VERSION) {
 		// incompatible, replay format is too old
 		if (error_message != NULL) {
-			snprintf(error_message, REPLAY_HEADER_ERROR_MESSAGE_MAX,
+			snprintf_check(error_message, REPLAY_HEADER_ERROR_MESSAGE_MAX,
 			         "replay created with \"%s\"...\nReplay format version too old! (minimum %d, found %d)",
 			         header->implementation_name, REPLAY_FORMAT_MIN_VERSION, version_number);
 		}
@@ -138,7 +138,7 @@ int read_replay_header(replay_header_type* header, FILE* fp, char* error_message
 	if (deprecation_number > REPLAY_FORMAT_DEPRECATION_NUMBER) {
 		// incompatible, replay format is too new
 		if (error_message != NULL) {
-			snprintf(error_message, REPLAY_HEADER_ERROR_MESSAGE_MAX,
+			snprintf_check(error_message, REPLAY_HEADER_ERROR_MESSAGE_MAX,
 			         "replay created with \"%s\"...\nReplay deprecation number too new! (max %d, found %d)",
 			         header->implementation_name, REPLAY_FORMAT_DEPRECATION_NUMBER, deprecation_number);
 		}
@@ -198,7 +198,7 @@ void list_replay_files() {
 		replay_info_type* replay_info = &replay_list[num_replay_files - 1]; // current replay file
 		memset( replay_info, 0, sizeof( replay_info_type ) );
 		// store the filename of the replay
-		snprintf( replay_info->filename, POP_MAX_PATH, "%s/%s", replays_folder,
+		snprintf_check(replay_info->filename, POP_MAX_PATH, "%s/%s", replays_folder,
 					get_current_filename_from_directory_listing(directory_listing) );
 
 		// get the creation time
@@ -272,7 +272,7 @@ void start_with_replay_file(const char *filename) {
 		int ok = read_replay_header(&header, replay_fp, header_error_message);
 		if (!ok) {
 			char error_message[REPLAY_HEADER_ERROR_MESSAGE_MAX];
-			snprintf(error_message, REPLAY_HEADER_ERROR_MESSAGE_MAX,
+			snprintf_check(error_message, REPLAY_HEADER_ERROR_MESSAGE_MAX,
 			         "Error opening replay file: %s\n",
 			         header_error_message);
 			fprintf(stderr, "%s", error_message);
@@ -771,7 +771,7 @@ int save_recorded_replay() {
 	}
 
 	char full_filename[POP_MAX_PATH] = "";
-	snprintf(full_filename, sizeof(full_filename), "%s/%s.p1r", replays_folder, input_filename);
+	snprintf_check(full_filename, sizeof(full_filename), "%s/%s.p1r", replays_folder, input_filename);
 
 	// create the "replays" folder if it does not exist already
 #if defined WIN32 || _WIN32 || WIN64 || _WIN64

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -364,7 +364,7 @@ void draw_extras() {
 	}
 
 	// room number
-	char room_num[4];
+	char room_num[6];
 	snprintf(room_num, sizeof(room_num), "%d", drawn_room);
 	rect_type text_rect = {10, 10, 21, 30};
 	method_5_rect(&text_rect, 0, color_8_darkgray);

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -344,7 +344,7 @@ const char* get_quick_path(char* custom_path_buffer, size_t max_len) {
 		return quick_file;
 	}
 	// if playing a custom levelset, try to use the mod folder
-	snprintf(custom_path_buffer, max_len, "%s/%s", mod_data_path, quick_file /*QUICKSAVE.SAV*/ );
+	snprintf_check(custom_path_buffer, max_len, "%s/%s", mod_data_path, quick_file /*QUICKSAVE.SAV*/ );
 	return custom_path_buffer;
 }
 
@@ -1956,7 +1956,7 @@ const char* get_save_path(char* custom_path_buffer, size_t max_len) {
 		return save_file;
 	}
 	// if playing a custom levelset, try to use the mod folder
-	snprintf(custom_path_buffer, max_len, "%s/%s", mod_data_path, save_file /*PRINCE.SAV*/ );
+	snprintf_check(custom_path_buffer, max_len, "%s/%s", mod_data_path, save_file /*PRINCE.SAV*/ );
 	return custom_path_buffer;
 }
 

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -1764,9 +1764,7 @@ const rect_type rect_titles = {106,24,195,296};
 
 // seg000:17E6
 void __pascal far show_title() {
-	word textcolor;
 	load_opt_sounds(sound_50_story_2_princess, sound_55_story_1_absence); // main theme, story, princess door
-	textcolor = get_text_color(15, color_15_brightwhite, 0x800);
 	dont_reset_time = 0;
 	if(offscreen_surface) free_surface(offscreen_surface); // missing in original
 	offscreen_surface = make_offscreen_buffer(&screen_rect);
@@ -1775,41 +1773,41 @@ void __pascal far show_title() {
 	idle(); // modified
 	do_paused();
 
-	draw_image_2(0 /*main title image*/, chtab_title50, 0, 0, blitters_0_no_transp);
+	draw_full_image(TITLE_MAIN);
 	fade_in_2(offscreen_surface, 0x1000); //STUB
 	method_1_blit_rect(onscreen_surface_, offscreen_surface, &screen_rect, &screen_rect, blitters_0_no_transp);
 	current_sound = sound_54_intro_music; // added
 	play_sound_from_buffer(sound_pointers[sound_54_intro_music]); // main theme
 	start_timer(timer_0, 0x82);
-	draw_image_2(1 /*Broderbund Software presents*/, chtab_title50, 96, 106, blitters_0_no_transp);
+	draw_full_image(TITLE_PRESENTS);
 	do_wait(timer_0);
 
 	start_timer(timer_0, 0xCD);
 	method_1_blit_rect(onscreen_surface_, offscreen_surface, &rect_titles, &rect_titles, blitters_0_no_transp);
-	draw_image_2(0 /*main title image*/, chtab_title50, 0, 0, blitters_0_no_transp);
+	draw_full_image(TITLE_MAIN);
 	do_wait(timer_0);
 
 	start_timer(timer_0, 0x41);
 	method_1_blit_rect(onscreen_surface_, offscreen_surface, &rect_titles, &rect_titles, blitters_0_no_transp);
-	draw_image_2(0 /*main title image*/, chtab_title50, 0, 0, blitters_0_no_transp);
-	draw_image_2(2 /*a game by Jordan Mechner*/, chtab_title50, 96, 122, blitters_0_no_transp);
+	draw_full_image(TITLE_MAIN);
+	draw_full_image(TITLE_MECHNER);
 	do_wait(timer_0);
 
 	start_timer(timer_0, 0x10E);
 	method_1_blit_rect(onscreen_surface_, offscreen_surface, &rect_titles, &rect_titles, blitters_0_no_transp);
-	draw_image_2(0 /*main title image*/, chtab_title50, 0, 0, blitters_0_no_transp);
+	draw_full_image(TITLE_MAIN);
 	do_wait(timer_0);
 
 	start_timer(timer_0, 0xEB);
 	method_1_blit_rect(onscreen_surface_, offscreen_surface, &rect_titles, &rect_titles, blitters_0_no_transp);
-	draw_image_2(0 /*main title image*/, chtab_title50, 0, 0, blitters_0_no_transp);
-	draw_image_2(3 /*Prince Of Persia*/, chtab_title50, 24, 107, blitters_10h_transp);
-	draw_image_2(4 /*Copyright 1990 Jordan Mechner*/, chtab_title50, 48, 184, blitters_0_no_transp);
+	draw_full_image(TITLE_MAIN);
+	draw_full_image(TITLE_POP);
+	draw_full_image(TITLE_MECHNER);
 	do_wait(timer_0);
 
 	method_1_blit_rect(onscreen_surface_, offscreen_surface, &rect_titles, &rect_titles, blitters_0_no_transp);
-	draw_image_2(0 /*story frame*/, chtab_title40, 0, 0, blitters_0_no_transp);
-	draw_image_2(1 /*In the Sultan's absence*/, chtab_title40, 24, 25, textcolor);
+	draw_full_image(STORY_FRAME);
+	draw_full_image(STORY_ABSENCE);
 	current_target_surface = onscreen_surface_;
 	while (check_sound_playing()) {
 		idle();
@@ -1827,12 +1825,12 @@ void __pascal far show_title() {
 
 	load_title_images(1);
 	current_target_surface = offscreen_surface;
-	draw_image_2(0 /*story frame*/, chtab_title40, 0, 0, blitters_0_no_transp);
-	draw_image_2(2 /*Marry Jaffar*/, chtab_title40, 24, 25, textcolor);
+	draw_full_image(STORY_FRAME);
+	draw_full_image(STORY_MARRY);
 	fade_in_2(offscreen_surface, 0x800);
-	draw_image_2(0 /*main title image*/, chtab_title50, 0, 0, blitters_0_no_transp);
-	draw_image_2(3 /*Prince Of Persia*/, chtab_title50, 24, 107, blitters_10h_transp);
-	draw_image_2(4 /*Copyright 1990 Jordan Mechner*/, chtab_title50, 48, 184, blitters_0_no_transp);
+	draw_full_image(TITLE_MAIN);
+	draw_full_image(TITLE_POP);
+	draw_full_image(TITLE_MECHNER);
 	while (check_sound_playing()) {
 		idle();
 		do_paused();
@@ -1840,13 +1838,13 @@ void __pascal far show_title() {
 	}
 	transition_ltr();
 	pop_wait(timer_0, 0x78);
-	draw_image_2(0 /*story frame*/, chtab_title40, 0, 0, blitters_0_no_transp);
-	draw_image_2(4 /*credits*/, chtab_title40, 24, 26, textcolor);
+	draw_full_image(STORY_FRAME);
+	draw_full_image(STORY_CREDITS);
 	transition_ltr();
 	pop_wait(timer_0, 0x168);
 	if (hof_count) {
-		draw_image_2(0 /*story frame*/, chtab_title40, 0, 0, blitters_0_no_transp);
-		draw_image_2(3 /*Prince Of Persia*/, chtab_title50, 24, 24, blitters_10h_transp);
+		draw_full_image(STORY_FRAME);
+		draw_full_image(HOF_POP);
 		show_hof();
 		transition_ltr();
 		pop_wait(timer_0, 0xF0);
@@ -1919,17 +1917,26 @@ void __pascal far release_title_images() {
 }
 
 // seg000:1C3A
-void __pascal far draw_image_2(int id, chtab_type* chtab_ptr, int xpos, int ypos, int blit) {
-	image_type* source;
+void __pascal far draw_full_image(enum full_image_id id) {
 	image_type* decoded_image;
-	image_type* mask;
-	mask = NULL;
-	if (NULL == chtab_ptr) return;
-	source = chtab_ptr->images[id];
-	decoded_image = source;
-	if (blit != blitters_0_no_transp && blit != blitters_10h_transp) {
+	image_type* mask = NULL;
+	int xpos, ypos, blit;
+
+	if (id >= MAX_FULL_IMAGES) return;
+	if (NULL == *full_image[id].chtab) return;
+	decoded_image = (*full_image[id].chtab)->images[full_image[id].id];
+	blit = full_image[id].blitter;
+	xpos = full_image[id].xpos;
+	ypos = full_image[id].ypos;
+
+	switch (blit) {
+	case blitters_white:
+		blit = get_text_color(15, color_15_brightwhite, 0x800);
+		/* fall through */
+	default:
 		method_3_blit_mono(decoded_image, xpos, ypos, blitters_0_no_transp, blit);
-	} else if (blit == blitters_10h_transp) {
+		break;
+	case blitters_10h_transp:
 		if (graphics_mode == gmCga || graphics_mode == gmHgaHerc) {
 			//...
 		} else {
@@ -1939,8 +1946,10 @@ void __pascal far draw_image_2(int id, chtab_type* chtab_ptr, int xpos, int ypos
 		if (graphics_mode == gmCga || graphics_mode == gmHgaHerc) {
 			free_far(mask);
 		}
-	} else {
+		break;
+	case blitters_0_no_transp:
 		method_6_blit_img_to_scr(decoded_image, xpos, ypos, blit);
+		break;
 	}
 }
 

--- a/src/seg001.c
+++ b/src/seg001.c
@@ -587,12 +587,12 @@ void __pascal far end_sequence() {
 	offscreen_surface = make_offscreen_buffer(&screen_rect);
 	load_title_images(0);
 	current_target_surface = offscreen_surface;
-	draw_image_2(0 /*story frame*/, chtab_title40, 0, 0, 0);
-	draw_image_2(3 /*The tyrant Jaffar*/, chtab_title40, 24, 25, get_text_color(15, color_15_brightwhite, 0x800));
+	draw_full_image(STORY_FRAME);
+	draw_full_image(STORY_HAIL);
 	fade_in_2(offscreen_surface, 0x800);
 	pop_wait(timer_0, 900);
 	start_timer(timer_0, 240);
-	draw_image_2(0 /*main title image*/, chtab_title50, 0, 0, 0);
+	draw_full_image(TITLE_MAIN);
 	transition_ltr();
 	do_wait(timer_0);
 	for (hof_index = 0; hof_index < hof_count; ++hof_index) {
@@ -611,8 +611,8 @@ void __pascal far end_sequence() {
 		if (hof_count < MAX_HOF_COUNT) {
 			++hof_count;
 		}
-		draw_image_2(0 /*story frame*/, chtab_title40, 0, 0, 0);
-		draw_image_2(3 /*Prince Of Persia*/, chtab_title50, 24, 24, blitters_10h_transp);
+		draw_full_image(STORY_FRAME);
+		draw_full_image(HOF_POP);
 		show_hof();
 		offset4_rect_add(&rect, &hof_rects[hof_index], -4, -1, -40, -1);
 		peel = read_peel_from_screen(&rect);
@@ -629,7 +629,7 @@ void __pascal far end_sequence() {
 		hof_write();
 		pop_wait(timer_0, 120);
 		current_target_surface = offscreen_surface;
-		draw_image_2(0 /*main title image*/, chtab_title50, 0, 0, blitters_0_no_transp);
+		draw_full_image(TITLE_MAIN);
 		transition_ltr();
 	}
 	while (check_sound_playing() && !key_test_quit()) {

--- a/src/seg001.c
+++ b/src/seg001.c
@@ -767,7 +767,7 @@ const char* get_hof_path(char* custom_path_buffer, size_t max_len) {
 		return hof_file;
 	}
 	// if playing a custom levelset, try to use the mod folder
-	snprintf(custom_path_buffer, max_len, "%s/%s", mod_data_path, hof_file /*PRINCE.HOF*/ );
+	snprintf_check(custom_path_buffer, max_len, "%s/%s", mod_data_path, hof_file /*PRINCE.HOF*/ );
 	return custom_path_buffer;
 }
 

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -42,7 +42,7 @@ bool found_exe_dir = false;
 
 void find_exe_dir() {
 	if (found_exe_dir) return;
-	strncpy(exe_dir, g_argv[0], sizeof(exe_dir));
+	snprintf_check(exe_dir, sizeof(exe_dir), "%s", g_argv[0]);
 	char* last_slash = NULL;
 	char* pos = exe_dir;
 	for (char c = *pos; c != '\0'; c = *(++pos)) {
@@ -67,7 +67,7 @@ const char* locate_file_(const char* filename, char* path_buffer, int buffer_siz
 		// If failed, it may be that SDLPoP is being run from the wrong different working directory.
 		// We can try to rescue the situation by loading from the directory of the executable.
 		find_exe_dir();
-        snprintf(path_buffer, buffer_size, "%s/%s", exe_dir, filename);
+        snprintf_check(path_buffer, buffer_size, "%s/%s", exe_dir, filename);
         return (const char*) path_buffer;
 	}
 }
@@ -119,7 +119,7 @@ struct directory_listing_type {
 directory_listing_type* create_directory_listing_and_find_first_file(const char* directory, const char* extension) {
 	directory_listing_type* directory_listing = calloc(1, sizeof(directory_listing_type));
 	char search_pattern[POP_MAX_PATH];
-	snprintf(search_pattern, POP_MAX_PATH, "%s/*.%s", directory, extension);
+	snprintf_check(search_pattern, POP_MAX_PATH, "%s/*.%s", directory, extension);
 	WCHAR* search_pattern_UTF16 = WIN_UTF8ToString(search_pattern);
 	directory_listing->search_handle = FindFirstFileW( search_pattern_UTF16, &directory_listing->find_data );
 	SDL_free(search_pattern_UTF16);
@@ -327,11 +327,11 @@ static FILE* open_dat_from_root_or_data_dir(const char* filename) {
 	// if failed, try if the DAT file can be opened in the data/ directory, instead of the main folder
 	if (fp == NULL) {
 		char data_path[POP_MAX_PATH];
-		snprintf(data_path, sizeof(data_path), "data/%s", filename);
+		snprintf_check(data_path, sizeof(data_path), "data/%s", filename);
 
         if (!file_exists(data_path)) {
             find_exe_dir();
-            snprintf(data_path, sizeof(data_path), "%s/data/%s", exe_dir, filename);
+            snprintf_check(data_path, sizeof(data_path), "%s/data/%s", exe_dir, filename);
         }
 
 		// verify that this is a regular file and not a directory (otherwise, don't open)
@@ -354,7 +354,7 @@ dat_type *__pascal open_dat(const char *filename,int drive) {
 		if (!skip_mod_data_files) {
 			char filename_mod[POP_MAX_PATH];
 			// before checking the root directory, first try mods/MODNAME/
-			snprintf(filename_mod, sizeof(filename_mod), "%s/%s", mod_data_path, filename);
+			snprintf_check(filename_mod, sizeof(filename_mod), "%s/%s", mod_data_path, filename);
 			fp = fopen(filename_mod, "rb");
 		}
 		if (fp == NULL && !skip_normal_data_files) {
@@ -365,7 +365,7 @@ dat_type *__pascal open_dat(const char *filename,int drive) {
 	dat_table_type* dat_table = NULL;
 
 	dat_type* pointer = (dat_type*) calloc(1, sizeof(dat_type));
-	strncpy(pointer->filename, filename, sizeof(pointer->filename));
+	snprintf_check(pointer->filename, sizeof(pointer->filename), "%s", filename);
 	pointer->next_dat = dat_chain_ptr;
 	dat_chain_ptr = pointer;
 
@@ -1991,11 +1991,11 @@ sound_buffer_type* load_sound(int index) {
 				char filename[POP_MAX_PATH];
 				if (!skip_mod_data_files) {
 					// before checking the root directory, first try mods/MODNAME/
-					snprintf(filename, sizeof(filename), "%s/music/%s.ogg", mod_data_path, sound_name(index));
+					snprintf_check(filename, sizeof(filename), "%s/music/%s.ogg", mod_data_path, sound_name(index));
 					fp = fopen(filename, "rb");
 				}
 				if (fp == NULL && !skip_normal_data_files) {
-					snprintf(filename, sizeof(filename), "data/music/%s.ogg", sound_name(index));
+					snprintf_check(filename, sizeof(filename), "data/music/%s.ogg", sound_name(index));
 					fp = fopen(locate_file(filename), "rb");
 				}
 				if (fp == NULL) {
@@ -2571,7 +2571,7 @@ void load_from_opendats_metadata(int resource_id, const char* extension, FILE** 
 			if (len >= 5 && filename_no_ext[len-4] == '.') {
 				filename_no_ext[len-4] = '\0'; // terminate, so ".DAT" is deleted from the filename
 			}
-			snprintf(image_filename,sizeof(image_filename),"data/%s/res%d.%s",filename_no_ext, resource_id, extension);
+			snprintf_check(image_filename,sizeof(image_filename),"data/%s/res%d.%s",filename_no_ext, resource_id, extension);
 			if (!use_custom_levelset) {
 				//printf("loading (binary) %s",image_filename);
 				fp = fopen(locate_file(image_filename), "rb");
@@ -2580,7 +2580,7 @@ void load_from_opendats_metadata(int resource_id, const char* extension, FILE** 
 				if (!skip_mod_data_files) {
 					char image_filename_mod[POP_MAX_PATH];
 					// before checking data/, first try mods/MODNAME/data/
-					snprintf(image_filename_mod, sizeof(image_filename_mod), "%s/%s", mod_data_path, image_filename);
+					snprintf_check(image_filename_mod, sizeof(image_filename_mod), "%s/%s", mod_data_path, image_filename);
 					//printf("loading (binary) %s",image_filename_mod);
 					fp = fopen(locate_file(image_filename_mod), "rb");
 				}

--- a/src/types.h
+++ b/src/types.h
@@ -172,6 +172,7 @@ enum blitters {
 	// It seems to me that the "or" blitter can be safely replaced with the "transparent" blitter.
 	blitters_2_or = 2,
 	blitters_3_xor = 3, // used for the shadow
+	blitters_white = 8,
 	blitters_9_black = 9,
 	blitters_10h_transp = 0x10,
 	/* 0x40..0x4F will draw a monochrome image with color 0..15 */
@@ -182,6 +183,21 @@ enum blitters {
 	blitters_colored_flame = 0x100,
 	blitters_colored_flame_last = 0x13F,
 #endif
+};
+
+enum full_image_id {
+	TITLE_MAIN = 0,
+	TITLE_PRESENTS,
+	TITLE_GAME,
+	TITLE_POP,
+	TITLE_MECHNER,
+	HOF_POP,
+	STORY_FRAME,
+	STORY_ABSENCE,
+	STORY_MARRY,
+	STORY_HAIL,
+	STORY_CREDITS,
+	MAX_FULL_IMAGES
 };
 
 enum grmodes {
@@ -247,6 +263,13 @@ typedef struct chtab_type {
 	// This is a variable-size array, with n_images elements.
 	image_type* far images[0];
 } chtab_type;
+
+typedef struct full_image_type {
+	int id;
+	chtab_type** chtab;
+	enum blitters blitter;
+	int xpos, ypos;
+} full_image_type;
 
 #pragma pack(push,1)
 typedef struct rgb_type {


### PR DESCRIPTION
This cleans up the build for me under GCC 9.3, and with Debian's default packaging build flags, in order to prepare to package SDLPoP for Debian.