### PR TITLE
Fix linker error with USE_REPLAY disabled

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -736,5 +736,13 @@ void load_mod_options() {
 	turn_custom_options_on_off(use_custom_options);
 }
 
+int process_rw_write(SDL_RWops* rw, void* data, size_t data_size) {
+	return SDL_RWwrite(rw, data, data_size, 1);
+}
+
+int process_rw_read(SDL_RWops* rw, void* data, size_t data_size) {
+	return SDL_RWread(rw, data, data_size, 1);
+	// if this returns 0, most likely the end of the stream has been reached
+}
 
 

--- a/src/replay.c
+++ b/src/replay.c
@@ -306,15 +306,6 @@ void start_with_replay_file(const char *filename) {
 	}
 }
 
-int process_rw_write(SDL_RWops* rw, void* data, size_t data_size) {
-	return SDL_RWwrite(rw, data, data_size, 1);
-}
-
-int process_rw_read(SDL_RWops* rw, void* data, size_t data_size) {
-	return SDL_RWread(rw, data, data_size, 1);
-	// if this returns 0, most likely the end of the stream has been reached
-}
-
 // The functions options_process_* below each process (read/write) a section of options variables (using SDL_RWops)
 // This is I/O for the *binary* representation of the relevant options - this gets saved as part of a replay.
 


### PR DESCRIPTION
When compiling with USE_REPLAY disabled in `config.h` the executable fails at link time:

```
/usr/bin/ld: menu.o: in function `save_ingame_settings':
menu.c:(.text+0x31cd): undefined reference to `process_rw_write'
/usr/bin/ld: menu.o: in function `load_ingame_settings':
menu.c:(.text+0x346f): undefined reference to `process_rw_read'
collect2: error: ld returned 1 exit status
make: *** [Makefile:36: ../prince] Error 1
```
`process_rw_write` and `process_rw_read` are in `replay.c` and guarded by `#ifdef USE_REPLAY` but these functions are needed outside of replays.

`proto.h` suggests that these should be in `option.c`.

This PR moves these functions which allows the linker to complete without error.
