### PR TITLE
Remove fcntl.h dependency

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -27,7 +27,6 @@ extern "C" {
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <fcntl.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <stdint.h>

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -1978,27 +1978,26 @@ const char* get_save_path(char* custom_path_buffer, size_t max_len) {
 // seg000:1D45
 void __pascal far save_game() {
 	word success;
-	int handle;
+	FILE* handle;
 	success = 0;
 	char custom_save_path[POP_MAX_PATH];
 	const char* save_path = get_save_path(custom_save_path, sizeof(custom_save_path));
-	// no O_TRUNC
-	handle = open(save_path, O_WRONLY | O_CREAT | O_BINARY, 0600);
-	if (handle == -1) goto loc_1DB8;
-	if (write(handle, &rem_min, 2) == 2) goto loc_1DC9;
+	handle = fopen(save_path, "wb");
+	if (handle == NULL) goto loc_1DB8;
+	if (fwrite(&rem_min, 1, 2, handle) == 2) goto loc_1DC9;
 	loc_1D9B:
-	close(handle);
+	fclose(handle);
 	if (!success) {
-		unlink(save_path);
+		remove(save_path);
 	}
 	loc_1DB8:
 	if (!success) goto loc_1E18;
 	display_text_bottom("GAME SAVED");
 	goto loc_1E2E;
 	loc_1DC9:
-	if (write(handle, &rem_tick, 2) != 2) goto loc_1D9B;
-	if (write(handle, &current_level, 2) != 2) goto loc_1D9B;
-	if (write(handle, &hitp_beg_lev, 2) != 2) goto loc_1D9B;
+	if (fwrite(&rem_tick, 1, 2, handle) != 2) goto loc_1D9B;
+	if (fwrite(&current_level, 1, 2, handle) != 2) goto loc_1D9B;
+	if (fwrite(&hitp_beg_lev, 1, 2, handle) != 2) goto loc_1D9B;
 	success = 1;
 	goto loc_1D9B;
 	loc_1E18:
@@ -2010,22 +2009,22 @@ void __pascal far save_game() {
 
 // seg000:1E38
 short __pascal far load_game() {
-	int handle;
 	word success;
+	FILE* handle;
 	success = 0;
 	char custom_save_path[POP_MAX_PATH];
 	const char* save_path = get_save_path(custom_save_path, sizeof(custom_save_path));
-	handle = open(save_path, O_RDONLY | O_BINARY);
-	if (handle == -1) goto loc_1E99;
-	if (read(handle, &rem_min, 2) == 2) goto loc_1E9E;
+	handle = fopen(save_path, "rb");
+	if (handle == NULL) goto loc_1E99;
+	if (fread(&rem_min, 1, 2, handle) == 2) goto loc_1E9E;
 	loc_1E8E:
-	close(handle);
+	fclose(handle);
 	loc_1E99:
 	return success;
 	loc_1E9E:
-	if (read(handle, &rem_tick, 2) != 2) goto loc_1E8E;
-	if (read(handle, &start_level, 2) != 2) goto loc_1E8E;
-	if (read(handle, &hitp_beg_lev, 2) != 2) goto loc_1E8E;
+	if (fread(&rem_tick, 1, 2, handle) != 2) goto loc_1E8E;
+	if (fread(&start_level, 1, 2, handle) != 2) goto loc_1E8E;
+	if (fread(&hitp_beg_lev, 1, 2, handle) != 2) goto loc_1E8E;
 #ifdef USE_COPYPROT
 	if (enable_copyprot && custom->copyprot_level > 0) {
 		custom->copyprot_level = start_level;

--- a/src/seg001.c
+++ b/src/seg001.c
@@ -773,35 +773,33 @@ const char* get_hof_path(char* custom_path_buffer, size_t max_len) {
 
 // seg001:0F17
 void __pascal far hof_write() {
-	int handle;
+	FILE* handle;
 	char custom_hof_path[POP_MAX_PATH];
 	const char* hof_path = get_hof_path(custom_hof_path, sizeof(custom_hof_path));
-	// no O_TRUNC
-	handle = open(hof_path, O_WRONLY | O_CREAT | O_BINARY, 0600);
-	if (handle < 0 ||
-	    write(handle, &hof_count, 2) != 2 ||
-	    write(handle, &hof, sizeof(hof)) != sizeof(hof) ||
-	    close(handle))
+	handle = fopen(hof_path, "wb");
+	if (handle == NULL ||
+		fwrite(&hof_count, 1, 2, handle) != 2 ||
+		fwrite(&hof, 1, sizeof(hof), handle) != sizeof(hof))
 		perror(hof_path);
-	if (handle >= 0)
-		close(handle);
+	if (handle != NULL)
+		fclose(handle);
 }
 
 // seg001:0F6C
 void __pascal far hof_read() {
-	int handle;
+	FILE* handle;
 	hof_count = 0;
 	char custom_hof_path[POP_MAX_PATH];
 	const char* hof_path = get_hof_path(custom_hof_path, sizeof(custom_hof_path));
-	handle = open(hof_path, O_RDONLY | O_BINARY);
-	if (handle < 0)
+	handle = fopen(hof_path, "rb");
+	if (handle == NULL)
 		return;
-	if (read(handle, &hof_count, 2) != 2 ||
-	    read(handle, &hof, sizeof(hof)) != sizeof(hof)) {
+	if (fread(&hof_count, 1, 2, handle) != 2 ||
+		fread(&hof, 1, sizeof(hof), handle) != sizeof(hof)) {
 		perror(hof_path);
 		hof_count = 0;
 	}
-	close(handle);
+	fclose(handle);
 }
 
 // seg001:0FC3

--- a/src/seg001.c
+++ b/src/seg001.c
@@ -23,7 +23,6 @@ The authors of this program may be contacted at https://forum.princed.org
 #ifndef _MSC_VER // unistd.h does not exist in the Windows SDK.
 #include <unistd.h>
 #endif
-#include <fcntl.h>
 
 // data:4CB4
 short cutscene_wait_frames;


### PR DESCRIPTION
`fcntl.h` posix header is only used in a few functions to perform basic file read/writes.
This PR replaces the `fcntl.h` calls with `stdio.h` calls to remove this extra dependency.
stdio calls are already used throughout the code base so this also serves to consolidate some of the file APIs.

This has been tested on linux (ubuntu gcc) and windows (Dev-C++/mingw-64)