### PR TITLE
Remove SDL2_Mixer from Dev-C++ linkers

### DIFF
--- a/src/port_debug.dev
+++ b/src/port_debug.dev
@@ -12,7 +12,7 @@ ResourceIncludes=
 MakeIncludes=
 Compiler=-Wall -std=gnu99_@@_
 CppCompiler=-Wall_@@_
-Linker=-l"mingw32"_@@_-l"SDL2main"_@@_-l"SDL2.dll"_@@_-l"SDL2_image"_@@_-l"SDL2_mixer"_@@_
+Linker=-l"mingw32"_@@_-l"SDL2main"_@@_-l"SDL2.dll"_@@_-l"SDL2_image"_@@_
 IsCpp=0
 Icon=port_debug.ico
 ExeOutput=

--- a/src/port_release.dev
+++ b/src/port_release.dev
@@ -12,7 +12,7 @@ ResourceIncludes=
 MakeIncludes=
 Compiler=-Wall -std=gnu99_@@_-O2_@@_
 CppCompiler=-Wall_@@_-O2_@@_
-Linker=-l"mingw32"_@@_-l"SDL2main"_@@_-l"SDL2.dll"_@@_-l"SDL2_image"_@@_-l"SDL2_mixer"_@@_
+Linker=-l"mingw32"_@@_-l"SDL2main"_@@_-l"SDL2.dll"_@@_-l"SDL2_image"_@@_
 IsCpp=0
 Icon=port_release.ico
 ExeOutput=


### PR DESCRIPTION
Dev-C++ IDE project file contain linkers to SDL_Mixer lib.
This was causing me a linker error when compiling as I did not have SDL_Mixer installed.

As mixer is not a requirement for this project, I figured it could be removed.

