### PR TITLE
cmake: elif to elseif

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,7 +115,7 @@ endif()
 
 if(WIN32)
     target_link_libraries(prince mingw32 SDL2main SDL2 SDL2_image)
-elif(APPLE)
+elseif(APPLE)
     target_link_libraries(prince SDL2main SDL2 SDL2_image m)
 else() # Linux, *BSD, etc.
     target_link_libraries(prince SDL2 SDL2_image m)


### PR DESCRIPTION
`elif` is not a valid cmake expression, (although weirdly it does seem to work is some versions of cmake)

See: https://cmake.org/cmake/help/v3.0/command/elseif.html
cmake documentation have no reference to `elif` anywhere.

I was getting this error when cross compiling win32 version with Ubuntu
```
CMake Error at CMakeLists.txt:118 (elif):
  Unknown CMake command "elif".
```

This PR changes to `elif` to match the cmake documentation. 