### PR TITLE
Add option to disable HW acceleration

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -33,6 +33,10 @@ The authors of this program may be contacted at https://forum.princed.org
 #define SDLPOP_VERSION "1.20"
 #define WINDOW_TITLE "Prince of Persia (SDLPoP) v" SDLPOP_VERSION
 
+// Enable or disable the SDL hardware accelerated renderer backend
+// Uses a software backend otherwise
+#define USE_HW_ACCELERATION
+
 // Enable or disable fading.
 // Fading used to be very buggy, but now it works correctly.
 #define USE_FADE

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -2343,7 +2343,12 @@ void __pascal far set_gr_mode(byte grmode) {
 	                           pop_window_width, pop_window_height, flags);
 	// Make absolutely sure that VSync will be off, to prevent timer issues.
 	SDL_SetHint(SDL_HINT_RENDER_VSYNC, "0");
-	renderer_ = SDL_CreateRenderer(window_, -1 , SDL_RENDERER_ACCELERATED | SDL_RENDERER_TARGETTEXTURE);
+#ifdef USE_HW_ACCELERATION
+	const Uint32 RENDER_BACKEND = SDL_RENDERER_ACCELERATED;
+#else
+	const Uint32 RENDER_BACKEND = SDL_RENDERER_SOFTWARE;
+#endif
+	renderer_ = SDL_CreateRenderer(window_, -1 , RENDER_BACKEND | SDL_RENDERER_TARGETTEXTURE);
 	SDL_RendererInfo renderer_info;
 	if (SDL_GetRendererInfo(renderer_, &renderer_info) == 0) {
 		if (renderer_info.flags & SDL_RENDERER_TARGETTEXTURE) {


### PR DESCRIPTION
This PR adds a #def in `config.h` to disable HW acceleration and use the software SDL backend.
This is useful for platforms that support SDL2, but not the HW accelerated backend.
The option is enabled (to use HW acceleration) by default as per current master.

https://wiki.libsdl.org/SDL_RendererFlags