### PR TITLE
Move load_dos_exe_modifications prototype to proto.h

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -447,8 +447,6 @@ void set_options_to_default() {
 	turn_custom_options_on_off(0);
 }
 
-void load_dos_exe_modifications(const char* folder_name);
-
 void load_global_options() {
 	set_options_to_default();
 	ini_load(locate_file("SDLPoP.ini"), global_ini_callback); // global configuration

--- a/src/proto.h
+++ b/src/proto.h
@@ -649,6 +649,7 @@ void check_mod_param();
 void load_mod_options();
 int process_rw_write(SDL_RWops* rw, void* data, size_t data_size);
 int process_rw_read(SDL_RWops* rw, void* data, size_t data_size);
+void load_dos_exe_modifications(const char* folder_name);
 
 // REPLAY.C
 #ifdef USE_REPLAY


### PR DESCRIPTION
Just moves a stray prototype to `proto.h`