### PR TITLE
Add Github Action Build Script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,96 @@
+name: Build
+
+on:
+  pull_request:
+    branches: [ master ]
+  push:
+    branches: [ master ]
+
+jobs:
+  #BUILD LINUX
+  Linux:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Install and Setup Dependencies
+      run: |
+        sudo apt update
+        sudo apt install libsdl2-dev libsdl2-image-dev
+
+    - name: Compile
+      run: |
+        cd src/
+        cmake .
+        make
+
+    # Only create artifact on a push to master
+    - if: github.event_name == 'push' 
+      name: Upload Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: SDLPoP_Linux
+        path: |
+          data
+          doc
+          mods
+          prince
+          SDLPoP.ini
+
+  #BUILD WIN32
+  Windows:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install and Setup Dependencies
+      run: |
+        sudo apt install mingw-w64
+
+        # Symlink windres
+        sudo ln -s /usr/bin/i686-w64-mingw32-windres /usr/bin/windres
+
+        # Setup SDL2 and SDL2_Image
+        cd ~
+        wget https://libsdl.org/release/SDL2-devel-2.0.12-mingw.tar.gz
+        wget https://libsdl.org/projects/SDL_image/release/SDL2_image-devel-2.0.5-mingw.tar.gz
+        tar xzf SDL2-devel-2.0.12-mingw.tar.gz
+        tar xzf SDL2_image-devel-2.0.5-mingw.tar.gz
+        sudo cp -r SDL2-2.0.12/i686-w64-mingw32/* /usr/i686-w64-mingw32/
+        sudo cp -r SDL2_image-2.0.5/i686-w64-mingw32/* /usr/i686-w64-mingw32/
+
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name : Compile
+      run: |
+        cd src/
+        cmake -DWIN32=1 -DCMAKE_SYSTEM_NAME=Windows \
+                        -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc \
+                        -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++ .
+        make
+
+    - name : Collate Output Files
+      run: |
+        cp ~/SDL2-2.0.12/i686-w64-mingw32/bin/SDL2.dll SDL2.dll
+        cp ~/SDL2_image-2.0.5/i686-w64-mingw32/bin/SDL2_image.dll SDL2_image.dll
+        cp ~/SDL2_image-2.0.5/i686-w64-mingw32/bin/zlib1.dll zlib1.dll
+        cp ~/SDL2_image-2.0.5/i686-w64-mingw32/bin/libpng16-16.dll libpng16-16.dll
+
+    # Only create artifact on a push to master
+    - if: github.event_name == 'push'
+      name: Upload Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: SDLPoP_Win32
+        path: |
+          data
+          doc
+          mods
+          prince.exe
+          SDLPoP.ini
+          SDL2.dll
+          SDL2_image.dll
+          zlib1.dll
+          libpng16-16.dll


### PR DESCRIPTION
This PR adds a Github Actions script to automatically compile binaries (Windows and Linux) for new changes to master.

It does the following:

1. For each new PR to master, it will compile a Linux and Windows binary in the background to confirm no compilation/syntax errors are introduced.
2. For each new push to master, it will upload the Linux and Windows binaries as a zipped 'Artifact', viewable under the 'Actions' tab. (Users must be logged into github to download Artifacts). Output filenames are timestamped.

Compilation for all cases is performed using cmake to generate the makefile.
* Linux uses Ubuntu GCC
* Windows uses i686-w64-mingw32-gcc [cross compilation via Ubuntu])

It does not publish binaries to 'Releases'. Historically it looks like that has been done manually (probably after alot of testing to confirm it is stable). Although this can be changed.

Example output artifacts (These are zip files):
![image](https://user-images.githubusercontent.com/21236406/90453104-d7978c80-e12e-11ea-8a16-4f3b147c8737.png)

Example outputs/build logs etc can be seen in my fork (Built from current [master](https://github.com/NagyD/SDLPoP/tree/becf8c20d5ef1006e6a60756d996a2512b0574bf)), 
https://github.com/Ryzee119/SDLPoPX/actions/runs/219189949

I have not created a build status badge for the readme, but this can be done in a follow up PR.