### PR TITLE
"Remember guard hp" for non-standard guards

### DIFF
--- a/src/seg002.c
+++ b/src/seg002.c
@@ -183,7 +183,7 @@ void __pascal far enter_guard() {
 	}
 
 	#ifdef REMEMBER_GUARD_HP
-	int remembered_hp = (curr_guard_color & 0xF0) >> 4;
+	int remembered_hp = (level.guards_color[room_minus_1] & 0xF0) >> 4;
 	#endif
 	curr_guard_color &= 0x0F; // added; only least significant 4 bits are used for guard color
 


### PR DESCRIPTION
The "remember guard hp" fix does not work for non-standard Guards (fat, vizier) because the value of their `curr_guard_color` is 0.