### PR TITLE
only check for replaying when USE_REPLAY is defined

### DIFF
--- a/src/seg006.c
+++ b/src/seg006.c
@@ -1234,7 +1234,11 @@ void __pascal far control_kid() {
 	if (grab_timer != 0) {
 		--grab_timer;
 	}
+#ifdef USE_REPLAY
 	if (current_level == 0 && !play_demo_level && !replaying) {
+#else
+	if (current_level == 0 && !play_demo_level) {
+#endif
 		do_demo();
 		control();
 		// The player can start a new game or load a saved game during the demo.


### PR DESCRIPTION
Hello,

replaying is only known if USE_REPLAY is defined. Therefore I put the if line in an `#ifdef`-block.
If USE_REPLAY is not defined, replaying is removed from the condition expression.