### PR TITLE
Replace zero size array members

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -9,7 +9,7 @@ BIN = ../prince
 
 OS      := $(shell uname)
 
-CPPFLAGS += -Wall -D_GNU_SOURCE=1
+CPPFLAGS += -Wall -D_XOPEN_SOURCE=700
 CFLAGS += -std=c99 -O2
 
 ifeq ($(OS),Darwin)

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,7 +10,7 @@ BIN = ../prince
 OS      := $(shell uname)
 
 CPPFLAGS += -Wall -D_GNU_SOURCE=1
-CFLAGS += -std=gnu99 -O2
+CFLAGS += -std=c99 -O2
 
 ifeq ($(OS),Darwin)
 LIBS := $(shell sdl2-config --libs) -lSDL2_image

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,7 +10,7 @@ BIN = ../prince
 OS      := $(shell uname)
 
 CPPFLAGS += -Wall -D_XOPEN_SOURCE=700
-CFLAGS += -std=c99 -O2
+CFLAGS += -std=c11 -O2
 
 ifeq ($(OS),Darwin)
 LIBS := $(shell sdl2-config --libs) -lSDL2_image

--- a/src/types.h
+++ b/src/types.h
@@ -546,19 +546,17 @@ typedef struct digi_new_type { // wave in 1.3 and 1.4 (and PoP2)
 } digi_new_type;
 SDL_COMPILE_TIME_ASSERT(digi_new_type, sizeof(digi_new_type) == 9);
 
-typedef struct midi_type {
-	char chunk_type[4];
-	dword chunk_length;
-	union {
-		struct {
+typedef struct midi_type_header {
 			word format;
 			word num_tracks;
 			word delta;
-			byte tracks[0];
-		} header;
-		byte data[0];
-	};
+} midi_type_header;
 
+typedef struct midi_type {
+	char chunk_type[4];
+	dword chunk_length;
+	midi_type_header header;
+	byte tracks[];
 } midi_type;
 
 typedef struct ogg_type {
@@ -589,16 +587,8 @@ typedef struct sound_buffer_type {
 typedef struct midi_raw_chunk_type {
 	char chunk_type[4];
 	dword chunk_length;
-	union {
-		struct {
-			word format;
-			word num_tracks;
-			word time_division;
-			byte tracks[0];
-		} header;
-		byte data[0];
-	};
-
+	midi_type_header header;
+	byte tracks[];
 } midi_raw_chunk_type;
 
 typedef struct midi_event_type {


### PR DESCRIPTION
Hello,

follow up from https://github.com/NagyD/SDLPoP/pull/224, there were still some zero size array members left.
I replaced them with flexible array members. This caused problems, because flexible array members are not allowed in unions.
Therefore the anonymous struct was put into it's own named struct.

This change enables compilation using `-stc=c99`, instead of `gnu99`, which should increase compatibility with C-compilers.

Using `-D_XOPEN_SOURCE=700` instead of `-D_GNU_SOURCE` should increase portability.

Compiling with `-Wextra -Wpedantic`, the compiler issued a warning, that anonymous unions are an extension in C11. The easiest fix could be using `-std=c11` or is there a reason for using C99?

Best regards,
BarrOff  