### PR TITLE
Quicksave during feather fall mode

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -112,7 +112,7 @@ enable_lighting = false
 ; Turn on game fixes and enhancements.
 ; Below, you can pick which fixes/enhancements will be active.
 ; NB. If use_fixes_and_enhancements is set to 'false', all of the below options are disabled.
-use_fixes_and_enhancements = false
+use_fixes_and_enhancements = true
 
 ; Adds a way to crouch immediately after climbing up: press down and forward simultaneously.
 ; In the original game, this could not be done (pressing down always causes the kid to climb down).
@@ -225,6 +225,9 @@ fix_hang_on_teleport = true
 
 ; You can enter closed exit doors after you met the shadow or Jaffar died, or after you opened one of multiple exits.
 fix_exit_door = true
+
+; You cannot save game while floating in feather mode.
+fix_quicksave_during_feather = true
 
 
 [CustomGameplay]

--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -112,7 +112,7 @@ enable_lighting = false
 ; Turn on game fixes and enhancements.
 ; Below, you can pick which fixes/enhancements will be active.
 ; NB. If use_fixes_and_enhancements is set to 'false', all of the below options are disabled.
-use_fixes_and_enhancements = true
+use_fixes_and_enhancements = false
 
 ; Adds a way to crouch immediately after climbing up: press down and forward simultaneously.
 ; In the original game, this could not be done (pressing down always causes the kid to climb down).

--- a/src/data.h
+++ b/src/data.h
@@ -887,6 +887,7 @@ extern word cheats_enabled INIT(= 0);
 #ifdef USE_DEBUG_CHEATS
 extern byte debug_cheats_enabled INIT(= 0);
 extern byte is_timer_displayed INIT(= 0);
+extern byte is_feather_timer_displayed INIT(= 0);
 #endif
 
 #ifdef USE_MENU

--- a/src/menu.c
+++ b/src/menu.c
@@ -196,6 +196,7 @@ enum setting_ids {
 	SETTING_FIX_HIDDEN_FLOORS_DURING_FLASHING,
 	SETTING_FIX_HANG_ON_TELEPORT,
 	SETTING_FIX_EXIT_DOOR,
+	SETTING_FIX_QUICKSAVE_DURING_FEATHER,
 	SETTING_USE_CUSTOM_OPTIONS,
 	SETTING_START_MINUTES_LEFT,
 	SETTING_START_TICKS_LEFT,
@@ -547,6 +548,10 @@ setting_type gameplay_settings[] = {
 				.linked = &fixes_saved.fix_exit_door, .required = &use_fixes_and_enhancements,
 				.text = "Fix exit doors",
 				.explanation = "You can enter closed exit doors after you met the shadow or Jaffar died, or after you opened one of multiple exits."},
+		{.id = SETTING_FIX_QUICKSAVE_DURING_FEATHER, .style = SETTING_STYLE_TOGGLE,
+				.linked = &fixes_saved.fix_quicksave_during_feather, .required = &use_fixes_and_enhancements,
+				.text = "Fix quick save in feather mode",
+				.explanation = "You cannot save game while floating in feather mode."},
 };
 
 NAMES_LIST(tile_type_setting_names, {

--- a/src/options.c
+++ b/src/options.c
@@ -272,6 +272,7 @@ static int global_ini_callback(const char *section, const char *name, const char
 		process_boolean("fix_hidden_floors_during_flashing", &fixes_saved.fix_hidden_floors_during_flashing);
 		process_boolean("fix_hang_on_teleport", &fixes_saved.fix_hang_on_teleport);
 		process_boolean("fix_exit_door", &fixes_saved.fix_exit_door);
+		process_boolean("fix_quicksave_during_feather", &fixes_saved.fix_quicksave_during_feather);
 	}
 
 	if (check_ini_section("CustomGameplay")) {

--- a/src/proto.h
+++ b/src/proto.h
@@ -597,6 +597,7 @@ const rect_type far * __pascal far method_5_rect(const rect_type far *rect,int b
 void draw_rect_with_alpha(const rect_type* rect, byte color, byte alpha);
 image_type far * __pascal far method_6_blit_img_to_scr(image_type far *image,int xpos,int ypos,int blit);
 void reset_timer(int timer_index);
+double get_ticks_per_sec(int timer_index);
 void set_timer_length(int timer_index, int length);
 void __pascal start_timer(int timer_index, int length);
 int __pascal do_wait(int timer_index);

--- a/src/replay.c
+++ b/src/replay.c
@@ -363,6 +363,7 @@ void options_process_fixes(SDL_RWops* rw, rw_process_func_type process_func) {
 	process(fixes_options_replay.fix_hidden_floors_during_flashing);
 	process(fixes_options_replay.fix_hang_on_teleport);
 	process(fixes_options_replay.fix_exit_door);
+	process(fixes_options_replay.fix_quicksave_during_feather);
 }
 
 void options_process_custom_general(SDL_RWops* rw, rw_process_func_type process_func) {

--- a/src/seg003.c
+++ b/src/seg003.c
@@ -497,16 +497,33 @@ void __pascal far timers() {
 		--resurrect_time;
 	}
 
-	if (is_feather_fall) is_feather_fall++;
+	if (fixes->fix_quicksave_during_feather) {
+		if (is_feather_fall > 0) {
+			--is_feather_fall;
+			if (is_feather_fall == 0) {
+				if (check_sound_playing()) {
+					stop_sounds();
+				}
 
-	if (is_feather_fall && (!check_sound_playing() || is_feather_fall > 225)) {
-		printf("slow fall ended at: rem_min = %d, rem_tick = %d\n", rem_min, rem_tick);
-		printf("length = %d ticks\n", is_feather_fall);
-#ifdef USE_REPLAY
-		if (recording) special_move = MOVE_EFFECT_END;
-		if (!replaying) // during replays, feather effect gets cancelled in do_replay_move()
-#endif
-		is_feather_fall = 0;
+				printf("slow fall ended at: rem_min = %d, rem_tick = %d\n", rem_min, rem_tick);
+				printf("length = %d ticks\n", is_feather_fall);
+	#ifdef USE_REPLAY
+				if (recording) special_move = MOVE_EFFECT_END;
+	#endif
+			}
+		}
+	} else {
+		if (is_feather_fall) is_feather_fall++;
+
+		if (is_feather_fall && (!check_sound_playing() || is_feather_fall > 225)) {
+			printf("slow fall ended at: rem_min = %d, rem_tick = %d\n", rem_min, rem_tick);
+			printf("length = %d ticks\n", is_feather_fall);
+	#ifdef USE_REPLAY
+			if (recording) special_move = MOVE_EFFECT_END;
+			if (!replaying) // during replays, feather effect gets cancelled in do_replay_move()
+	#endif
+			is_feather_fall = 0;
+		}
 	}
 
 	// Special event: mouse

--- a/src/seg006.c
+++ b/src/seg006.c
@@ -1242,6 +1242,13 @@ void __pascal far control_kid() {
 	word key;
 	if (Char.alive < 0 && hitp_curr == 0) {
 		Char.alive = 0;
+		// stop feather fall when kid dies
+		if (fixes->fix_quicksave_during_feather && is_feather_fall > 0) {
+			is_feather_fall = 0;
+			if (check_sound_playing()) {
+				stop_sounds();
+			}
+		}
 	}
 	if (grab_timer != 0) {
 		--grab_timer;

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -2597,7 +2597,8 @@ void draw_overlay() {
 		} else if (overlay == 3) { // Feather timer
 #ifdef USE_DEBUG_CHEATS
 			char timer_text[32];
-			snprintf(timer_text, sizeof(timer_text), "%02d:%02d", is_feather_fall / 12, is_feather_fall % 12);
+			int ticks_per_sec = get_ticks_per_sec(timer_1);
+			snprintf(timer_text, sizeof(timer_text), "%02d:%02d", is_feather_fall / ticks_per_sec, is_feather_fall % ticks_per_sec);
 			int expected_numeric_chars = 6;
 			int extra_numeric_chars = MAX(0, strnlen(timer_text, sizeof(timer_text)) - 8);
 			int line_width = 5 + (expected_numeric_chars + extra_numeric_chars) * 9;

--- a/src/types.h
+++ b/src/types.h
@@ -1212,6 +1212,7 @@ typedef struct fixes_options_type {
 	byte fix_hidden_floors_during_flashing;
 	byte fix_hang_on_teleport;
 	byte fix_exit_door;
+	byte fix_quicksave_during_feather;
 } fixes_options_type;
 
 #define NUM_GUARD_SKILLS 12
@@ -1324,5 +1325,7 @@ typedef struct custom_options_type {
 typedef struct directory_listing_type directory_listing_type;
 
 #define BASE_FPS 60
+
+#define FEATHER_FALL_LENGTH 18.75
 
 #endif


### PR DESCRIPTION
I added an ability to quick save in feather mode as discussed here: https://forum.princed.org/viewtopic.php?f=126&p=32402

There is now the "Fix quicksave during feather" option that makes the `is_feather_fall` variable to act as a timer. In debug cheats mode F button now shows the remaining feather fall time similar to the T button for the game timer.

Pause menu now pauses the feather fall music since timer variables do not increment/decrement. When the game continues, the music starts from the beginning until the feather mode timer stops. In my mod I have the music from the correct position but I am using SDLMixer with OGG files. I am not sure how to do this with digi sound streams.

When you restore a quick save saved in feather mode without the fix option enabled, the feather mode does not get enabled to prevent cheating since I can only start it from the beginning.