### PR TITLE
Fix for spiked/chomped/bumped guards teleported into the wrong room

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -210,9 +210,6 @@ The authors of this program may be contacted at https://forum.princed.org
 // A guard standing on a door top (with floor) should not become inactive.
 #define FIX_DOORTOP_DISABLING_GUARD
 
-// Fix guards appearing in the current room when they fell into spikes in an adjacent room. (Example: original level 11, room 22.)
-#define FIX_SPIKED_GUARD
-
 // Fix graphical glitches with an opening gate:
 // 1. with a loose floor above and a wall above-right.
 // 2. with the top half of a big pillar above-right.

--- a/src/seg002.c
+++ b/src/seg002.c
@@ -902,7 +902,25 @@ void __pascal far hurt_by_sword() {
 				Char.direction < dir_0_right && // looking left
 				(curr_tile2 == tiles_4_gate || get_tile_at_char() == tiles_4_gate)
 			) {
-				Char.x = x_bump[tile_col - (curr_tile2 != tiles_4_gate) + 5] + 7;
+				#ifdef FIX_OFFSCREEN_GUARDS_DISAPPEARING
+				// a guard can get teleported to the other side of kid's room
+				// when fighting between rooms and hitting a gate
+				if (fixes->fix_offscreen_guards_disappearing) {
+					short gate_col = tile_col;
+					if (curr_room != Char.room)	{
+						if (curr_room == level.roomlinks[Char.room - 1].right) {
+							gate_col += 10;
+						} else if (curr_room == level.roomlinks[Char.room - 1].left) {
+							gate_col -= 10;
+						}
+					}
+					Char.x = x_bump[gate_col - (curr_tile2 != tiles_4_gate) + 5] + 7;
+				} else {
+				#endif
+					Char.x = x_bump[tile_col - (curr_tile2 != tiles_4_gate) + 5] + 7;
+				#ifdef FIX_OFFSCREEN_GUARDS_DISAPPEARING
+				}
+				#endif
 				Char.x = char_dx_forward(10);
 			}
 			Char.y = y_land[Char.curr_row + 1];

--- a/src/seg002.c
+++ b/src/seg002.c
@@ -113,7 +113,6 @@ void __pascal far enter_guard() {
 	room_minus_1 = drawn_room - 1;
 	frame = Char.frame; // hm?
 	guard_tile = level.guards_tile[room_minus_1];
-
 #ifndef FIX_OFFSCREEN_GUARDS_DISAPPEARING
 	if (guard_tile >= 30) return;
 #else
@@ -138,11 +137,18 @@ void __pascal far enter_guard() {
 			if (other_guard_dir == dir_0_right) other_guard_x -= 9; // only retrieve a guard if they will be visible
 			if (other_guard_dir == dir_FF_left) other_guard_x += 1; // getting these right was mostly trial and error
 			// only retrieve offscreen guards
-			if (!(other_guard_x < 58 + 4)) return;
+			if (!(other_guard_x < 58 + 4)) {
+				// check the left offscreen guard
+				if (left_guard_tile >= 0 && left_guard_tile < 30) {
+					goto loc_left_guard_tile;
+				}
+				return;
+			}
 			delta_x = 140; // guard leaves to the left
 			guard_tile = right_guard_tile;
 		}
 		else if (left_guard_tile >= 0 && left_guard_tile < 30) {
+loc_left_guard_tile:
 			other_room_minus_1 = room_L - 1;
 			other_guard_x = level.guards_x[other_room_minus_1];
 			other_guard_dir = level.guards_dir[other_room_minus_1];

--- a/src/seg004.c
+++ b/src/seg004.c
@@ -453,7 +453,25 @@ void __pascal far chomped() {
 	#endif
 		curr_room_modif[curr_tilepos] |= 0x80; // put blood
 	if (Char.frame != frame_178_chomped && Char.room == curr_room) {
-		Char.x = x_bump[tile_col + 5] + 7;
+		#ifdef FIX_OFFSCREEN_GUARDS_DISAPPEARING
+		// a guard can get teleported to the other side of kid's room
+		// when hitting a chomper in another room
+		if (fixes->fix_offscreen_guards_disappearing) {
+			short chomper_col = tile_col;
+			if (curr_room != Char.room)	{
+				if (curr_room == level.roomlinks[Char.room - 1].right) {
+					chomper_col += 10;
+				} else if (curr_room == level.roomlinks[Char.room - 1].left) {
+					chomper_col -= 10;
+				}
+			}
+			Char.x = x_bump[chomper_col + 5] + 7;
+		} else {
+		#endif
+			Char.x = x_bump[tile_col + 5] + 7;
+		#ifdef FIX_OFFSCREEN_GUARDS_DISAPPEARING
+		}
+		#endif
 		Char.x = char_dx_forward(7 - !Char.direction);
 		Char.y = y_land[Char.curr_row + 1];
 		take_hp(100);

--- a/src/seg005.c
+++ b/src/seg005.c
@@ -211,29 +211,29 @@ void __pascal far land() {
 
 // seg005:01B7
 void __pascal far spiked() {
-	int forward_bump = 8;
 	// If someone falls into spikes, those spikes become harmless (to others).
 	curr_room_modif[curr_tilepos] = 0xFF;
-#ifdef FIX_SPIKED_GUARD
-	// If someone falls into spikes in a different room
-	if (Char.room != curr_room /* && fixes->??? */) {
-		if (Char.charid == charid_0_kid) {
-			// fixes an issue where kid falling into spikes disappears
-			if (Char.curr_col == -1) {
-				draw_kid();
-				forward_bump = Char.direction == dir_0_right ? -6 : 16;
-			}
-		} else {
-			// remove guard from the original room
-			level.guards_tile[Char.room - 1] = -1;
-		}
-		// draw character in the correct room
-		Char.room = curr_room;
-	}
-#endif
 	Char.y = y_land[Char.curr_row + 1];
-	Char.x = x_bump[tile_col + 5] + 10;
-	Char.x = char_dx_forward(forward_bump);
+	#ifdef FIX_OFFSCREEN_GUARDS_DISAPPEARING
+	// a guard can get teleported to the other side of kid's room
+	// when landing on spikes in another room
+	if (fixes->fix_offscreen_guards_disappearing) {
+		short spike_col = tile_col;
+		if (curr_room != Char.room)	{
+			if (curr_room == level.roomlinks[Char.room - 1].right) {
+				spike_col += 10;
+			} else if (curr_room == level.roomlinks[Char.room - 1].left) {
+				spike_col -= 10;
+			}
+		}
+		Char.x = x_bump[spike_col + 5] + 10;
+	} else {
+	#endif
+		Char.x = x_bump[tile_col + 5] + 10;
+	#ifdef FIX_OFFSCREEN_GUARDS_DISAPPEARING
+	}
+	#endif
+	Char.x = char_dx_forward(8);
 	Char.fall_y = 0;
 	play_sound(sound_48_spiked); // something spiked
 	take_hp(100);


### PR DESCRIPTION
See https://forum.princed.org/viewtopic.php?p=32617#p32617

There was also an issue in the `enter_guard` method where the offscreen guard from the room on the left would not show up if there is a regular guard in the room on the right. This is the spikes scenario on level 11.