### PR TITLE
Adding compilation-time flag to disable all fixes for vanilla execution

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -102,6 +102,9 @@ The authors of this program may be contacted at https://forum.princed.org
 
 // The mentioned tricks can be found here: https://www.popot.org/documentation.php?doc=Tricks
 
+// A compilation-time option to disable all fixes. Useful for automated solving tools that require vanilla emulation. 
+#ifndef DISABLE_ALL_FIXES
+
 // If a room is linked to itself on the left, the closing sounds of the gates in that room can't be heard.
 #define FIX_GATE_SOUNDS
 
@@ -247,6 +250,7 @@ The authors of this program may be contacted at https://forum.princed.org
 // Explanation: https://forum.princed.org/viewtopic.php?p=32701#p32701
 #define FIX_CAPED_PRINCE_SLIDING_THROUGH_GATE
 
+#endif
 
 // Debug features:
 

--- a/src/config.h
+++ b/src/config.h
@@ -250,7 +250,7 @@ The authors of this program may be contacted at https://forum.princed.org
 // Explanation: https://forum.princed.org/viewtopic.php?p=32701#p32701
 #define FIX_CAPED_PRINCE_SLIDING_THROUGH_GATE
 
-#endif
+#endif // ifndef DISABLE_ALL_FIXES
 
 // Debug features:
 

--- a/src/seg006.c
+++ b/src/seg006.c
@@ -73,7 +73,7 @@ int __pascal far find_room_of_tile() {
 		//find_room_of_tile();
 		goto again;
 	}
-#ifdef FIX_CORNER_GRAB
+#ifndef FIX_CORNER_GRAB
 	// if (tile_row < 0) was here originally
 	if (tile_row < 0) {
 		tile_row += 3;

--- a/src/seg007.c
+++ b/src/seg007.c
@@ -876,6 +876,7 @@ void __pascal far loose_shake(int arg_0) {
 			// Sounds 20,21,22: loose floor shaking
 			sound_id = prandom(2) + sound_20_loose_shake_1;
 		} while(sound_id == last_loose_sound);
+		prandom(2); // For vanilla pop compatibility, an RNG cycle is wasted here
 		if (sound_flags & sfDigi) {
 			last_loose_sound = sound_id;
 			// random sample rate (10500..11500)

--- a/src/seg008.c
+++ b/src/seg008.c
@@ -1432,7 +1432,7 @@ void __pascal far draw_leveldoor() {
 
 // seg008:1E0C
 void __pascal far get_room_address(int room) {
-	if (room < 0 || room > 24) printf("Tried to access room %d, not in 0..24.\n", room);
+	//if (room < 0 || room > 24) printf("Tried to access room %d, not in 0..24.\n", room);
 	loaded_room = (word) room;
 	if (room) {
 		curr_room_tiles = &level.fg[(room-1)*30];

--- a/src/types.h
+++ b/src/types.h
@@ -24,13 +24,16 @@ The authors of this program may be contacted at https://forum.princed.org
 #define STB_VORBIS_HEADER_ONLY
 #include "stb_vorbis.c"
 
-#if !defined(_MSC_VER)
-# include <SDL2/SDL.h>
-# include <SDL2/SDL_image.h>
-#else
+//#if !defined(_MSC_VER)
+//# include <SDL2/SDL.h>
+//# include <SDL2/SDL_image.h>
+//#else
+// These headers for SDL seem to be the pkgconfig/meson standard as per the
+// latest versions. If the old ones should be used, the ifdef must be used
+// to compare versions. 
 # include <SDL.h>
 # include <SDL_image.h>
-#endif
+//#endif
 
 #if SDL_BYTEORDER != SDL_LIL_ENDIAN
 #error This program is not (yet) prepared for big endian CPUs, please contact the author.


### PR DESCRIPTION
Me and mooskagh are developing an automated tool to find the best strats for speedrunning. The recently added bug fixes are set by defines in config.h that cannot be disabled on runtime. These bugs might be useful for an any% run, though.

I propose adding this flag that allows us to disable all fixes at compilation time.