### PR TITLE
Exit room timer save

### DIFF
--- a/src/seg000.c
+++ b/src/seg000.c
@@ -343,6 +343,8 @@ int quick_process(process_func_type process_func) {
 	process(ctrl1_up);
 	process(ctrl1_down);
 	process(ctrl1_shift2);
+ // For proper emulation of the overflow glitch
+ process(exit_room_timer);
 	// replay recording state
 #ifdef USE_REPLAY
 	process(curr_tick);

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -421,7 +421,7 @@ void restore_room_after_quick_load() {
 	// Get rid of "press button" message if kid was dead before quickload.
 	text_time_total = text_time_remaining = 0;
 	//next_sound = current_sound = -1;
-	exit_room_timer = 0;
+ //exit_room_timer = 0; // This prevents the overflow glitch from happening
 }
 
 int quick_load() {
@@ -1251,6 +1251,7 @@ void __pascal far check_the_end() {
 			end_sequence();
 		}
 		different_room = 1;
+		exit_room_timer = 2; // Added to remember exit room timer
 		loadkid();
 		anim_tile_modif();
 		start_chompers();


### PR DESCRIPTION
The overflow glitch that allows for skips on level 10 and 12 requires that the exit room timer is conserved through savestates.

Currently in SDLpop, if you quicksave just before grabbing the ledge and quickload, then the overflow glitch won't happen. This pull request solves the problem and allows our bot to find the trick.