### PR TITLE
Adjust SDL2 headers search path in CMake or macOS builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${SDLPoP_SOURCE_DIR}/..")
 #set(SDL2 "/usr/local/Cellar/sdl2/2.0.5")
 
 if (NOT(WIN32) AND (DEFINED SDL2))
-    include_directories(${SDL2}/include)
+    include_directories(${SDL2}/include/SDL2)
     link_directories(${SDL2}/lib)
 endif()
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,13 +12,11 @@ OS      := $(shell uname)
 CPPFLAGS += -Wall -D_GNU_SOURCE=1
 CFLAGS += -std=gnu99 -O2
 
-ifeq ($(OS),Darwin)
-LIBS := $(shell sdl2-config --libs) -lSDL2_image
-CFLAGS += -I/opt/local/include
-CPPFLAGS += -D_THREAD_SAFE -DOSX
-else
-LIBS := $(shell pkg-config --libs   sdl2 SDL2_image)
+LIBS := $(shell pkg-config --libs sdl2 SDL2_image)
 CFLAGS += $(shell pkg-config --cflags sdl2 SDL2_image)
+
+ifeq ($(OS),Darwin)
+CPPFLAGS += -D_THREAD_SAFE -DOSX
 endif
 
 all: $(BIN)


### PR DESCRIPTION
SDLPoP includes `SDL.h` as `#include <SDL.h>` (not `#include <SDL2/SDL.h>`). The current `Makefile` works on Linux because `pkg-config` correctly passes cflags as `#{prefix}/include/SDL2`. Unfortunately, on macOS, `/opt/local/include` won't work - it would be `/opt/local/include/SDL2`.

Instead of fixing this with a hard-coded path, just rely on `pkg-config` to set the appropriate paths on both macOS and Linux. An additional benefit here is that people who have SDL2/SDL2_image installed in non-standard locations can adjust `PKG_CONFIG_PATH` to point at the appropriate search locations.

The same issue exists for the CMake-based build, which this PR also fixes.

We encountered this issue while packaging SDLPoP 1.22 for Homebrew - see downstream discussion at https://github.com/Homebrew/homebrew-core/pull/80795. Thanks!