### PR TITLE
Add gamecontroller hotplug support

### DIFF
--- a/src/seg009.c
+++ b/src/seg009.c
@@ -3416,7 +3416,20 @@ void process_events() {
 #endif
 				}
 				break;
+			case SDL_CONTROLLERDEVICEADDED:
+				SDL_GameControllerOpen(event.cdevice.which);
+				break;
+			case SDL_CONTROLLERDEVICEREMOVED:
+				if (sdl_controller_ == SDL_GameControllerFromInstanceID(event.cdevice.which)) {
+					sdl_controller_ = NULL;
+					is_joyst_mode = 0;
+					is_keyboard_mode = 1;
+				}
+				SDL_GameControllerClose(SDL_GameControllerFromInstanceID(event.cdevice.which));
+				break;
 			case SDL_CONTROLLERBUTTONDOWN:
+				//Make sure sdl_controller_ always points to the active controller
+				sdl_controller_ = SDL_GameControllerFromInstanceID(event.cdevice.which);
 #ifdef USE_AUTO_INPUT_MODE
 				if (!is_joyst_mode) {
 					is_joyst_mode = 1;


### PR DESCRIPTION
Allows an SDL Gamecontroller compatible device to be plugged in anytime.

Currently the controller must be plugged in prior to starting.

Tested on Windows with the mingwx64 build using my xbox one and 360 controllers.