### PR TITLE
Add pkgconfig to the list of required dependencies on macOS

### DIFF
--- a/doc/Readme.txt
+++ b/doc/Readme.txt
@@ -412,10 +412,10 @@ macOS
 -----
 * Get SDL2 and dependencies
 	1. Install "port" from https://www.macports.org/
-	2. `sudo port install libsdl2 libsdl2_image`
+	2. `sudo port install libsdl2 libsdl2_image pkgconfig`
 	* or
 	1. Install "homebrew"
-	2. `brew install sdl2 sdl2_image`
+	2. `brew install sdl2 sdl2_image pkg-config`
 
 * Get development tools:
 	1. Install Xcode.


### PR DESCRIPTION
Hello there,

`pkgconfig` is required to compile the project. Without it, the `make` fails:

```
make: pkg-config: Command not found
make: pkg-config: Command not found
gcc -Wall -D_GNU_SOURCE=1 -D_THREAD_SAFE -DOSX -std=gnu99 -O2   -c main.c
In file included from main.c:21:
In file included from ./common.h:54:
./types.h:34:11: fatal error: 'SDL.h' file not found
# include <SDL.h>
          ^~~~~~~
1 error generated.
make: *** [main.o] Error 1
```

Thanks!