### PR TITLE
Optional fix for jumping over guard

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -248,6 +248,9 @@ fix_caped_prince_sliding_through_gate = true
 ; Guards become inactive if they are standing on a door top (with floor), or if the prince is standing on a door top.
 fix_doortop_disabling_guard = true
 
+; Prince can jump over guards with a properly timed running jump
+fix_jumping_over_guard = true
+
 
 [CustomGameplay]
 ; Turn on customization options.

--- a/src/config.h
+++ b/src/config.h
@@ -269,6 +269,11 @@ The authors of this program may be contacted at https://forum.princed.org
 #define FIX_BLACK_RECT
 // TODO: Also fix the shadow not turning around and/or falling into the wall? Or would that break mods?
 
+// The prince can jump over a guard with a properly timed running jump.
+// His character's x coordinate ends up in the column behind the guard which causes the bump sequence
+// not to work correctly.
+#define FIX_JUMPING_OVER_GUARD
+
 #endif // ifndef DISABLE_ALL_FIXES
 
 // Prince can jump 2 stories up in feather fall mode

--- a/src/menu.c
+++ b/src/menu.c
@@ -199,6 +199,7 @@ enum setting_ids {
 	SETTING_FIX_QUICKSAVE_DURING_FEATHER,
 	SETTING_FIX_CAPED_PRINCE_SLIDING_THROUGH_GATE,
 	SETTING_FIX_DOORTOP_DISABLING_GUARD,
+	SETTING_FIX_JUMPING_OVER_GUARD,
 	SETTING_enable_super_high_jump,
 	SETTING_USE_CUSTOM_OPTIONS,
 	SETTING_START_MINUTES_LEFT,
@@ -567,6 +568,10 @@ setting_type gameplay_settings[] = {
 				.linked = &fixes_saved.fix_doortop_disabling_guard, .required = &use_fixes_and_enhancements,
 				.text = "Fix door top disabling guard",
 				.explanation = "Guards become inactive if they are standing on a door top (with floor), or if the prince is standing on a door top."},
+		{.id = SETTING_FIX_JUMPING_OVER_GUARD, .style = SETTING_STYLE_TOGGLE,
+				.linked = &fixes_saved.fix_jumping_over_guard, .required = &use_fixes_and_enhancements,
+				.text = "Fix jumping over guard",
+				.explanation = "Prince can jump over guards with a properly timed running jump."},
 };
 
 NAMES_LIST(tile_type_setting_names, {

--- a/src/options.c
+++ b/src/options.c
@@ -281,6 +281,7 @@ static int global_ini_callback(const char *section, const char *name, const char
 		process_boolean("fix_caped_prince_sliding_through_gate", &fixes_saved.fix_caped_prince_sliding_through_gate);
 		process_boolean("fix_doortop_disabling_guard", &fixes_saved.fix_doortop_disabling_guard);
 		process_boolean("enable_super_high_jump", &fixes_saved.enable_super_high_jump);
+		process_boolean("fix_jumping_over_guard", &fixes_saved.fix_jumping_over_guard);
 	}
 
 	if (check_ini_section("CustomGameplay")) {

--- a/src/replay.c
+++ b/src/replay.c
@@ -370,6 +370,7 @@ void options_process_fixes(SDL_RWops* rw, rw_process_func_type process_func) {
 	process(fixes_options_replay.fix_quicksave_during_feather);
 	process(fixes_options_replay.fix_caped_prince_sliding_through_gate);
 	process(fixes_options_replay.fix_doortop_disabling_guard);
+	process(fixes_options_replay.fix_jumping_over_guard);
 }
 
 void options_process_custom_general(SDL_RWops* rw, rw_process_func_type process_func) {

--- a/src/seg003.c
+++ b/src/seg003.c
@@ -649,6 +649,15 @@ void __pascal far bump_into_opponent() {
 			}
 			#endif
 
+			#ifdef FIX_JUMPING_OVER_GUARD
+			if (fixes->fix_jumping_over_guard) {
+				if ((Char.direction == dir_0_right && Char.x > Opp.x) ||
+				        (Char.direction == dir_FF_left && Char.x < Opp.x)) {
+					Char.x = Opp.x;
+				}
+			}
+			#endif
+
 			Char.y = y_land[Char.curr_row + 1];
 			Char.fall_y = 0;
 			seqtbl_offset_char(seq_47_bump); // bump into opponent

--- a/src/types.h
+++ b/src/types.h
@@ -1230,6 +1230,7 @@ typedef struct fixes_options_type {
 	byte fix_caped_prince_sliding_through_gate;
 	byte fix_doortop_disabling_guard;
 	byte enable_super_high_jump;
+	byte fix_jumping_over_guard;
 } fixes_options_type;
 
 #define NUM_GUARD_SKILLS 12


### PR DESCRIPTION
When prince does a running jump near a guard, his character's x coordinate could end up in the column behind the guard which causes the bump sequence not to work correctly.

This is a well known trick/bug by speed runners. But in some mods it might be desirable to avoid this behavior.

Pre fix video: https://youtu.be/mbwwMdgq1Bo
Post fix video: https://youtu.be/Xbz2avOibKY
It even affects level 3 skeleton: https://youtu.be/zyTBlrQiyZA

