### PR TITLE
Fix warnings on non-explicit casts and use of comma as a binary operator

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -1522,7 +1522,7 @@ void draw_setting(setting_type* setting, rect_type* parent, int* y_offset, int i
 					increase_setting(setting, value);
 				} else {
 					char* value_text = print_setting_value(setting, value);
-					int value_text_width = get_line_width(value_text, strlen(value_text));
+					int value_text_width = get_line_width(value_text, (int)strlen(value_text));
 					rect_type left_hitbox = right_hitbox;
 					left_hitbox.left -= (value_text_width + 10);
 					left_hitbox.right -= (value_text_width + 5);
@@ -1543,7 +1543,7 @@ void draw_setting(setting_type* setting, rect_type* parent, int* y_offset, int i
 		show_text_with_color(&text_rect, 1, -1, value_text, selected_color);
 
 		if (highlighted_setting_id == setting->id) {
-			int value_text_width = get_line_width(value_text, strlen(value_text));
+			int value_text_width = get_line_width(value_text, (int)strlen(value_text));
 			draw_image_with_blending(arrowhead_right_image, text_rect.right + 2, text_rect.top);
 			draw_image_with_blending(arrowhead_left_image, text_rect.right - value_text_width - 6, text_rect.top);
 		}
@@ -2154,7 +2154,7 @@ unsigned int crc32c(unsigned char *message, size_t size) {
 	i = 0;
 	crc = 0xFFFFFFFF;
 	while (size--) {
-		byte = message[i];
+      byte = message[i];
 		crc = (crc >> 8) ^ table[(crc ^ byte) & 0xFF];
 		i = i + 1;
 	}

--- a/src/midi.c
+++ b/src/midi.c
@@ -511,7 +511,7 @@ void midi_callback(void *userdata, Uint8 *stream, int len) {
 			int64_t us_to_next_pause = ticks_to_next_pause * us_per_beat / ticks_per_beat;
 			int64_t us_needed = frames_needed * ONE_SECOND_IN_US / mixing_freq;
 			int64_t advance_us = MIN(us_to_next_pause, us_needed);
-			int available_frames = ((advance_us * mixing_freq) + ONE_SECOND_IN_US - 1) / ONE_SECOND_IN_US; // round up.
+			int available_frames = (int)(((advance_us * mixing_freq) + ONE_SECOND_IN_US - 1) / ONE_SECOND_IN_US); // round up.
 			int advance_frames = MIN(available_frames, frames_needed);
 			advance_us = advance_frames * ONE_SECOND_IN_US / mixing_freq; // recalculate, in case the rounding up increased this.
 			short* temp_buffer = malloc(advance_frames * 4);
@@ -584,7 +584,7 @@ void midi_callback(void *userdata, Uint8 *stream, int len) {
 					printf("MIDI: Couldn't figure out how long to delay (this is a bug)\n");
 					quit(1);
 				}
-				ticks_to_next_pause = first_next_pause_tick - midi_current_pos;
+				ticks_to_next_pause = (int)(first_next_pause_tick - midi_current_pos);
 				if (ticks_to_next_pause < 0) {
 					printf("Tried to delay a negative amount of time (this is a bug)\n"); // This should never happen?
 					quit(1);

--- a/src/options.c
+++ b/src/options.c
@@ -535,7 +535,7 @@ void load_dos_exe_modifications(const char* folder_name) {
 	int dos_version = -1;
 	struct stat info;
 	if (fp != NULL && fstat(fileno(fp), &info) == 0 && info.st_size > 0) {
-		dos_version = identify_dos_exe_version(info.st_size);
+		dos_version = identify_dos_exe_version((int)info.st_size);
 	} else {
 		// PRINCE.EXE not found, try to search for other .EXE files in the same folder.
 		directory_listing_type* directory_listing = create_directory_listing_and_find_first_file(folder_name, "exe");
@@ -545,7 +545,7 @@ void load_dos_exe_modifications(const char* folder_name) {
 				snprintf(filename, sizeof(filename), "%s/%s", folder_name, current_filename);
 				fp = fopen(filename, "rb");
 				if (fp != NULL && fstat(fileno(fp), &info) == 0 && info.st_size > 0) {
-					dos_version = identify_dos_exe_version(info.st_size);
+					dos_version = identify_dos_exe_version((int)info.st_size);
 					if (dos_version >= 0) {
 						break; // We found a DOS executable with the right size!
 					}
@@ -575,7 +575,7 @@ void load_dos_exe_modifications(const char* folder_name) {
 		do { \
 			static const int offsets[6] = __VA_ARGS__; \
 			int offset = offsets[dos_version]; \
-			read_ok = read_exe_bytes(x, nbytes, exe_memory, offset, info.st_size); \
+			read_ok = read_exe_bytes(x, nbytes, exe_memory, offset, (int)info.st_size); \
 		} while(0)
 
 		// Offsets and comparisons are derived from princehack.xml
@@ -778,11 +778,11 @@ void load_mod_options() {
 }
 
 int process_rw_write(SDL_RWops* rw, void* data, size_t data_size) {
-	return SDL_RWwrite(rw, data, data_size, 1);
+	return (int)SDL_RWwrite(rw, data, data_size, 1);
 }
 
 int process_rw_read(SDL_RWops* rw, void* data, size_t data_size) {
-	return SDL_RWread(rw, data, data_size, 1);
+	return (int)SDL_RWread(rw, data, data_size, 1);
 	// if this returns 0, most likely the end of the stream has been reached
 }
 

--- a/src/replay.c
+++ b/src/replay.c
@@ -258,7 +258,7 @@ void change_working_dir_to_sdlpop_root(void) {
 	char* exe_path = g_argv[0];
 	// strip away everything after the last slash or backslash in the path
 	int len;
-	for (len = strlen(exe_path); len > 0; --len) {
+	for (len = (int)strlen(exe_path); len > 0; --len) {
 		if (exe_path[len] == '\\' || exe_path[len] == '/') {
 			break;
 		}
@@ -476,7 +476,7 @@ replay_options_section_type replay_options_sections[] = {
 
 // output the current options to a memory buffer (e.g. to remember them before a replay is loaded)
 size_t save_options_to_buffer(void* options_buffer, size_t max_size, process_options_section_func_type* process_section_func) {
-	SDL_RWops* rw = SDL_RWFromMem(options_buffer, max_size);
+	SDL_RWops* rw = SDL_RWFromMem(options_buffer, (int)max_size);
 	process_section_func(rw, process_rw_write);
 	Sint64 section_size = SDL_RWtell(rw);
 	if (section_size < 0) section_size = 0;
@@ -486,7 +486,7 @@ size_t save_options_to_buffer(void* options_buffer, size_t max_size, process_opt
 
 // restore the options from a memory buffer (e.g. reapply the original options after a replay is finished)
 void load_options_from_buffer(void* options_buffer, size_t options_size, process_options_section_func_type* process_section_func) {
-	SDL_RWops* rw = SDL_RWFromMem(options_buffer, options_size);
+	SDL_RWops* rw = SDL_RWFromMem(options_buffer, (int)options_size);
 	process_section_func(rw, process_rw_read);
 	SDL_RWclose(rw);
 }
@@ -813,10 +813,10 @@ int save_recorded_replay(const char* full_filename)
 		Sint64 seconds = time(NULL);
 		fwrite(&seconds, sizeof(seconds), 1, replay_fp);
 		// levelset_name
-		putc(strnlen(levelset_name, UINT8_MAX), replay_fp); // length of the levelset name (is zero for original levels)
+		putc((int)strnlen(levelset_name, UINT8_MAX), replay_fp); // length of the levelset name (is zero for original levels)
 		fputs(levelset_name, replay_fp);
 		// implementation name
-		putc(strnlen(implementation_name, UINT8_MAX), replay_fp);
+		putc((int)strnlen(implementation_name, UINT8_MAX), replay_fp);
 		fputs(implementation_name, replay_fp);
 		// embed a savestate into the replay
 		fwrite(&savestate_size, sizeof(savestate_size), 1, replay_fp);
@@ -825,7 +825,7 @@ int save_recorded_replay(const char* full_filename)
 		// save the options, organized per section
 		byte temp_options[POP_MAX_OPTIONS_SIZE];
 		for (int i = 0; i < COUNT(replay_options_sections); ++i) {
-			dword section_size = save_options_to_buffer(temp_options, sizeof(temp_options), replay_options_sections[i].section_func);
+			dword section_size = (dword)save_options_to_buffer(temp_options, sizeof(temp_options), replay_options_sections[i].section_func);
 			fwrite(&section_size, sizeof(section_size), 1, replay_fp);
 			fwrite(temp_options, section_size, 1, replay_fp);
 		}

--- a/src/seg008.c
+++ b/src/seg008.c
@@ -1450,12 +1450,12 @@ void __pascal far draw_leveldoor() {
 		}
 	}
 	leveldoor_ybottom = ybottom - (modifier_left & 3) - 48;
-	for (var_6 = ybottom - modifier_left;
-		add_backtable(id_chtab_6_environment, 33 /*level door bottom*/, draw_xh + 1, 0, leveldoor_ybottom, blitters_0_no_transp, 0),
-			var_6 > leveldoor_ybottom;
-		leveldoor_ybottom += 4) {
-		;
-	} // runs at least once?
+	var_6 = ybottom - modifier_left;
+	do { // runs at least once
+		add_backtable(id_chtab_6_environment, 33 /*level door bottom*/, draw_xh + 1, 0, leveldoor_ybottom, blitters_0_no_transp, 0);
+		if (var_6 > leveldoor_ybottom) leveldoor_ybottom += 4;
+		else break;
+	} while (true);
 	add_backtable(id_chtab_6_environment, 34 /*level door top*/, draw_xh + 1, 0, draw_main_y - 64, blitters_0_no_transp, 0);
 }
 

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -245,7 +245,7 @@ void __pascal far clear_kbd_buf() {
 word __pascal far prandom(word max) {
 	if (!seed_was_init) {
 		// init from current time
-		random_seed = time(NULL);
+		random_seed = (dword)time(NULL);
 		seed_was_init = 1;
 	}
 	random_seed = random_seed * 214013 + 2531011;
@@ -1331,7 +1331,7 @@ const rect_type far *__pascal draw_text(const rect_type far *rect_ptr,int x_alig
 void __pascal far show_text(const rect_type far *rect_ptr,int x_align,int y_align,const char far *text) {
 	// stub
 	//printf("show_text: %s\n",text);
-	draw_text(rect_ptr, x_align, y_align, text, strlen(text));
+	draw_text(rect_ptr, x_align, y_align, text, (int)strlen(text));
 }
 
 // seg009:04FF
@@ -2156,7 +2156,7 @@ sound_buffer_type* load_sound(int index) {
 				// Decoding the entire file immediately would make the loading time much longer.
 				// However, we can also create the decoder now, and only use it when we are actually playing the file.
 				// (In the audio callback, we'll decode chunks of samples to the output stream, as needed).
-				stb_vorbis* decoder = stb_vorbis_open_memory(file_contents, file_size, NULL, NULL);
+				stb_vorbis* decoder = stb_vorbis_open_memory(file_contents, (int)file_size, NULL, NULL);
 				if (decoder == NULL) {
 					free(file_contents);
 					break;
@@ -2782,7 +2782,7 @@ void load_from_opendats_metadata(int resource_id, const char* extension, FILE** 
 				struct stat buf;
 				if (fstat(fileno(fp), &buf) == 0) {
 					*result = data_directory;
-					*size = buf.st_size;
+					*size = (int)buf.st_size;
 				} else {
 					perror(image_filename);
 					fclose(fp);


### PR DESCRIPTION
This time double checked to work and not break the dialogs.
I did notice that, in the copy protection level, the letters are missing above the bottles. Is that a pre-existing issue?

Is the name / location of setup_dialog_settings acceptable?