### PR TITLE
Super high jump: prince should be able to grab the top tile from the edge

### DIFF
--- a/src/seg005.c
+++ b/src/seg005.c
@@ -693,6 +693,7 @@ void __pascal far grab_up_no_floor_behind() {
 // seg005:08E6
 void __pascal far jump_up() {
 	short distance;
+	word delta_x;
 	control_up = release_arrows();
 	distance = get_edge_distance();
 	if (distance < 4 && edge_type == 1) {
@@ -706,9 +707,15 @@ void __pascal far jump_up() {
 	}
 	#endif
 	#ifdef USE_SUPER_HIGH_JUMP
-    int char_col = get_tile_div_mod(back_delta_x(0) + dx_weight() - 6);
+	// kid should be able to grab 2 tiles above from an edge of a floor tile
+	if (is_feather_fall && !tile_is_floor(get_tile_above_char()) && curr_tile2 != tiles_20_wall) {
+		delta_x = Char.direction == dir_FF_left ? 1 : 3;
+	} else {
+		delta_x = 0;
+	}
+    int char_col = get_tile_div_mod(back_delta_x(delta_x) + dx_weight() - 6);
     get_tile(Char.room, char_col, Char.curr_row - 1);
-    if (curr_tile2 != tiles_20_wall && ! tile_is_floor(curr_tile2)) {
+    if (curr_tile2 != tiles_20_wall && !tile_is_floor(curr_tile2)) {
         if (fixes->enable_super_high_jump && is_feather_fall) { // super high jump can only happen in feather mode
             if (curr_room == 0 && Char.curr_row == 0) { // there is no room above
                 seqtbl_offset_char(seq_14_jump_up_into_ceiling);

--- a/src/types.h
+++ b/src/types.h
@@ -24,16 +24,16 @@ The authors of this program may be contacted at https://forum.princed.org
 #define STB_VORBIS_HEADER_ONLY
 #include "stb_vorbis.c"
 
-//#if !defined(_MSC_VER)
-//# include <SDL2/SDL.h>
-//# include <SDL2/SDL_image.h>
-//#else
+#if !defined(_MSC_VER)
+# include <SDL2/SDL.h>
+# include <SDL2/SDL_image.h>
+#else
 // These headers for SDL seem to be the pkgconfig/meson standard as per the
 // latest versions. If the old ones should be used, the ifdef must be used
 // to compare versions. 
 # include <SDL.h>
 # include <SDL_image.h>
-//#endif
+#endif
 
 #if SDL_BYTEORDER != SDL_LIL_ENDIAN
 #error This program is not (yet) prepared for big endian CPUs, please contact the author.


### PR DESCRIPTION
This commit fixes an issue where prince can only grab the tile 2 floors above from the tile behind. He should be able to grab it from the very edge of the same tile column for a similar behavior as a regular jump up.

https://youtu.be/dqByvAUA41I