### PR TITLE
Fix for Prince or guard falling through the floor during a strike

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -254,6 +254,9 @@ fix_jumping_over_guard = true
 ; Prince can fall 2 rooms down while climbing a loose tile in a room above. (Trick 153)
 fix_drop_2_rooms_climbing_loose_tile = true
 
+; Prince or guard can fall through the floor during a sword strike sequence.
+fix_falling_through_floor_during_sword_strike = true
+
 
 [CustomGameplay]
 ; Turn on customization options.

--- a/src/config.h
+++ b/src/config.h
@@ -281,6 +281,13 @@ The authors of this program may be contacted at https://forum.princed.org
 // See also: https://github.com/NagyD/SDLPoP/pull/272
 #define FIX_DROP_2_ROOMS_CLIMBING_LOOSE_TILE
 
+// The prince or a guard can fall through a floor during a sword strike even though there is a floor tile in front of him.
+// A strike sequence consists of 4 important frames, 151-154. Frame 153 is different from the other 3 because has a flag
+// that it "needs a floor". The problem is strike frames a pretty wide so the character's tile is not calculated correctly
+// causing him to visually fall through the floor.
+// This fix prevents falling during that frame treating it like it does not require a floor.
+#define FIX_FALLING_THROUGH_FLOOR_DURING_SWORD_STRIKE
+
 #endif // ifndef DISABLE_ALL_FIXES
 
 // Prince can jump 2 stories up in feather fall mode

--- a/src/menu.c
+++ b/src/menu.c
@@ -201,6 +201,7 @@ enum setting_ids {
 	SETTING_FIX_DOORTOP_DISABLING_GUARD,
 	SETTING_FIX_JUMPING_OVER_GUARD,
 	SETTING_FIX_DROP_2_ROOMS_CLIMBING_LOOSE_TILE,
+	SETTING_FIX_FALLING_THROUGH_FLOOR_DURING_SWORD_STRIKE,
 	SETTING_ENABLE_SUPER_HIGH_JUMP,
 	SETTING_USE_CUSTOM_OPTIONS,
 	SETTING_START_MINUTES_LEFT,
@@ -583,6 +584,10 @@ setting_type gameplay_settings[] = {
 				.linked = &fixes_saved.fix_drop_2_rooms_climbing_loose_tile, .required = &use_fixes_and_enhancements,
 				.text = "Fix dropping 2 rooms with loose tile",
 				.explanation = "Prince can fall 2 rooms down while climbing a loose tile in a room above. (Trick 153)"},
+		{.id = SETTING_FIX_FALLING_THROUGH_FLOOR_DURING_SWORD_STRIKE, .style = SETTING_STYLE_TOGGLE,
+				.linked = &fixes_saved.fix_falling_through_floor_during_sword_strike, .required = &use_fixes_and_enhancements,
+				.text = "Fix dropping through floor striking",
+				.explanation = "Prince or guard can fall through the floor during a sword strike sequence."},
 };
 
 NAMES_LIST(tile_type_setting_names, {

--- a/src/options.c
+++ b/src/options.c
@@ -283,6 +283,7 @@ static int global_ini_callback(const char *section, const char *name, const char
 		process_boolean("enable_super_high_jump", &fixes_saved.enable_super_high_jump);
 		process_boolean("fix_jumping_over_guard", &fixes_saved.fix_jumping_over_guard);
 		process_boolean("fix_drop_2_rooms_climbing_loose_tile", &fixes_saved.fix_drop_2_rooms_climbing_loose_tile);
+		process_boolean("fix_falling_through_floor_during_sword_strike", &fixes_saved.fix_falling_through_floor_during_sword_strike);
 	}
 
 	if (check_ini_section("CustomGameplay")) {

--- a/src/replay.c
+++ b/src/replay.c
@@ -373,6 +373,7 @@ void options_process_fixes(SDL_RWops* rw, rw_process_func_type process_func) {
 	process(fixes_options_replay.fix_doortop_disabling_guard);
 	process(fixes_options_replay.fix_jumping_over_guard);
 	process(fixes_options_replay.fix_drop_2_rooms_climbing_loose_tile);
+	process(fixes_options_replay.fix_falling_through_floor_during_sword_strike);
 }
 
 void options_process_custom_general(SDL_RWops* rw, rw_process_func_type process_func) {

--- a/src/seg006.c
+++ b/src/seg006.c
@@ -1011,6 +1011,14 @@ void __pascal far set_char_collision() {
 // seg006:0815
 void __pascal far check_on_floor() {
 	if (cur_frame.flags & FRAME_NEEDS_FLOOR) {
+#ifdef FIX_FALLING_THROUGH_FLOOR_DURING_SWORD_STRIKE
+        // We do not want the Prince or a guard to fall during that frame because it looks like he is falling
+        // through a floor. It is caused by a combination of the frame width and the dx value in the frame table.
+        // Other 3 frames in the sequence do not have the "FRAME_NEEDS_FLOOR" flag enabled but the frame 153 does.
+        if (fixes->fix_falling_through_floor_during_sword_strike) {
+			if (Char.frame == frame_153_strike_3) return;
+        }
+#endif
 		if (get_tile_at_char() == tiles_20_wall) {
 			in_wall();
 		}

--- a/src/types.h
+++ b/src/types.h
@@ -1237,6 +1237,7 @@ typedef struct fixes_options_type {
 	byte enable_super_high_jump;
 	byte fix_jumping_over_guard;
 	byte fix_drop_2_rooms_climbing_loose_tile;
+	byte fix_falling_through_floor_during_sword_strike;
 } fixes_options_type;
 
 #define NUM_GUARD_SKILLS 12


### PR DESCRIPTION
The prince or a guard can fall through a floor during a sword strike even though there is a floor tile in front of him followed by a cliff/drop.

A strike sequence consists of 4 important frames, 151-154. Frame 153 is different from the other 3 because has a flag
that it "needs a floor". The problem is strike frames a pretty wide so the character's tile is not calculated correctly
causing him to visually fall through the floor.

This fix prevents falling during that frame by treating it like it does not require a floor.

Here are some videos of the bug. For the prince video I temporarily added an ability to draw a sword anytime but it can happen in a fight as well.

https://youtu.be/D5MiTmQrFD8
https://youtu.be/V59Z668bhWM

After the fix

https://youtu.be/mODEhtIy-bI