### PR TITLE
Use keyboard layout-aware keycodes for time cheat

### DIFF
--- a/src/seg000.c
+++ b/src/seg000.c
@@ -735,8 +735,7 @@ int __pascal far process_key() {
 				answer_text = /*&*/sprintf_temp;
 				need_show_text = 1;
 			break;
-			case SDL_SCANCODE_MINUS:
-			case SDL_SCANCODE_KP_MINUS:		// '-' --> subtract time cheat
+			case SDL_SCANCODE_KP_MINUS: // '-' --> subtract time cheat
 				if (rem_min > 1) --rem_min;
 
 #ifdef ALLOW_INFINITE_TIME
@@ -748,8 +747,7 @@ int __pascal far process_key() {
 				text_time_remaining = 0;
 				is_show_time = 1;
 			break;
-			case SDL_SCANCODE_EQUALS | WITH_SHIFT: // '+'
-			case SDL_SCANCODE_KP_PLUS:	   // '+' --> add time cheat
+			case SDL_SCANCODE_KP_PLUS: // '+' --> add time cheat
 
 #ifdef ALLOW_INFINITE_TIME
 				if (rem_min < 0) { // if negative/infinite, time runs 'forward'

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -3288,6 +3288,11 @@ void process_events() {
 				int modifier = event.key.keysym.mod;
 				int scancode = event.key.keysym.scancode;
 
+				switch (event.key.keysym.sym) {
+					case SDLK_MINUS: scancode = SDL_SCANCODE_KP_MINUS; break;
+					case SDLK_PLUS:  scancode = SDL_SCANCODE_KP_PLUS;  break;
+				}
+
 				// Handle these separately, so they won't interrupt things that are usually interrupted by a keypress. (pause, cutscene)
 #ifdef USE_FAST_FORWARD
 				if (scancode == SDL_SCANCODE_GRAVE) {


### PR DESCRIPTION
This ensures that the current keyboard layout determines the location of the
'-'/'+' keys, as would be expected, and helps especially when using tenkeyless
keyboards lacking a numpad. This mimics the behaviour of the original game when
run under DOSBox.