### PR TITLE
Make hardware acceleration a runtime option

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -46,6 +46,12 @@ start_fullscreen = false
 pop_window_width = default
 pop_window_height = default
 
+; Possible values:
+; * default = Auto, use hardware acceleration when available.
+; * true    = Force hardware acceleration.
+; * false   = Disable hardware acceleration.
+use_hardware_acceleration = default
+
 ; Render the game in the originally intended 4:3 aspect ratio.
 ; NB. Works best using a high resolution.
 use_correct_aspect_ratio = false

--- a/src/config.h
+++ b/src/config.h
@@ -33,10 +33,6 @@ The authors of this program may be contacted at https://forum.princed.org
 #define SDLPOP_VERSION "1.22"
 #define WINDOW_TITLE "Prince of Persia (SDLPoP) v" SDLPOP_VERSION
 
-// Enable or disable the SDL hardware accelerated renderer backend
-// Uses a software backend otherwise
-#define USE_HW_ACCELERATION
-
 // Enable or disable fading.
 // Fading used to be very buggy, but now it works correctly.
 #define USE_FADE

--- a/src/data.h
+++ b/src/data.h
@@ -732,6 +732,7 @@ extern char gamecontrollerdb_file[POP_MAX_PATH] INIT(= "");
 extern byte enable_quicksave INIT(= 1);
 extern byte enable_quicksave_penalty INIT(= 1);
 extern byte enable_replay INIT(= 1);
+extern byte use_hardware_acceleration INIT(= 2);
 extern byte use_correct_aspect_ratio INIT(= 0);
 extern byte use_integer_scaling INIT(= 0);
 extern byte scaling_type INIT(= 0);

--- a/src/menu.c
+++ b/src/menu.c
@@ -149,6 +149,7 @@ enum setting_ids {
 	SETTING_JOYSTICK_THRESHOLD,
 	SETTING_JOYSTICK_ONLY_HORIZONTAL,
 	SETTING_FULLSCREEN,
+	SETTING_USE_HARDWARE_ACCELERATION,
 	SETTING_USE_CORRECT_ASPECT_RATIO,
 	SETTING_USE_INTEGER_SCALING,
 	SETTING_SCALING_TYPE,
@@ -336,6 +337,7 @@ setting_type general_settings[] = {
 				.text = "Restore defaults...", .explanation = "Revert all settings to the default state."},
 };
 
+NAMES_LIST(use_hardware_acceleration_setting_names, {"OFF", "ON", "AUTO",});
 NAMES_LIST(scaling_type_setting_names, {"Sharp", "Fuzzy", "Blurry",});
 
 int integer_scaling_possible =
@@ -350,6 +352,13 @@ setting_type visuals_settings[] = {
 		{.id = SETTING_FULLSCREEN, .style = SETTING_STYLE_TOGGLE, .linked = &start_fullscreen,
 				.text = "Start fullscreen",
 				.explanation = "Start the game in fullscreen mode.\nYou can also toggle fullscreen by pressing Alt+Enter."},
+		{.id = SETTING_USE_HARDWARE_ACCELERATION, .style = SETTING_STYLE_NUMBER, .number_type = SETTING_BYTE, .max = 2,
+				.linked = &use_hardware_acceleration, .names_list = &use_hardware_acceleration_setting_names_list,
+				.text = "Use hardware acceleration",
+				.explanation = "Auto - Use hardware acceleration, if available.\n"
+				               "On - Force hardware acceleration.\n"
+				               "Off - Disable hardware acceleration.\n"
+				               "Note: This requires a restart."},
 		{.id = SETTING_USE_CORRECT_ASPECT_RATIO, .style = SETTING_STYLE_TOGGLE, .linked = &use_correct_aspect_ratio,
 				.text = "Use 4:3 aspect ratio",
 				.explanation = "Render the game in the originally intended 4:3 aspect ratio."
@@ -2149,6 +2158,7 @@ void process_ingame_settings_user_managed(SDL_RWops* rw, rw_process_func_type pr
 	process(joystick_only_horizontal);
 	process(enable_replay);
 	process(start_fullscreen);
+	process(use_hardware_acceleration);
 	process(use_correct_aspect_ratio);
 	process(use_integer_scaling);
 	process(scaling_type);

--- a/src/options.c
+++ b/src/options.c
@@ -78,6 +78,7 @@ int ini_load(const char *filename,
 	return 0;
 }
 
+NAMES_LIST(use_hardware_acceleration_names, {"false", "true", "default"}); // this is needed because use_hardware_acceleration is not a bool!
 NAMES_LIST(level_type_names, {"dungeon", "palace"});
 //NAMES_LIST(guard_type_names, {"guard", "fat", "skel", "vizier", "shadow"});
 // NAMES_LIST must start from 0, so I need KEY_VALUE_LIST if I want to assign a name to -1.
@@ -188,6 +189,7 @@ static int global_ini_callback(const char *section, const char *name, const char
 		process_boolean("start_fullscreen", &start_fullscreen);
 		process_word("pop_window_width", &pop_window_width, NULL);
 		process_word("pop_window_height", &pop_window_height, NULL);
+		process_byte("use_hardware_acceleration", &use_hardware_acceleration, &use_hardware_acceleration_names_list);
 		process_boolean("use_correct_aspect_ratio", &use_correct_aspect_ratio);
 		process_boolean("use_integer_scaling", &use_integer_scaling);
 		process_byte("scaling_type", &scaling_type, &scaling_type_names_list);
@@ -467,6 +469,7 @@ void set_options_to_default() {
 	enable_text = 1;
 	enable_info_screen = 1;
 	start_fullscreen = 0;
+	use_hardware_acceleration = 2;
 	use_correct_aspect_ratio = 0;
 	use_integer_scaling = 0;
 	scaling_type = 0;

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -2481,12 +2481,15 @@ void __pascal far set_gr_mode(byte grmode) {
 	                           pop_window_width, pop_window_height, flags);
 	// Make absolutely sure that VSync will be off, to prevent timer issues.
 	SDL_SetHint(SDL_HINT_RENDER_VSYNC, "0");
-#ifdef USE_HW_ACCELERATION
-	const Uint32 RENDER_BACKEND = SDL_RENDERER_ACCELERATED;
-#else
-	const Uint32 RENDER_BACKEND = SDL_RENDERER_SOFTWARE;
-#endif
-	renderer_ = SDL_CreateRenderer(window_, -1 , RENDER_BACKEND | SDL_RENDERER_TARGETTEXTURE);
+	flags = 0;
+	switch (use_hardware_acceleration) {
+		case 0:  flags |= SDL_RENDERER_SOFTWARE;    break;
+		case 1:  flags |= SDL_RENDERER_ACCELERATED; break;
+		case 2:  // let SDL decide
+		         // fallthrough!
+		default: break;
+	}
+	renderer_ = SDL_CreateRenderer(window_, -1 , flags | SDL_RENDERER_TARGETTEXTURE);
 	SDL_RendererInfo renderer_info;
 	if (SDL_GetRendererInfo(renderer_, &renderer_info) == 0) {
 		if (renderer_info.flags & SDL_RENDERER_TARGETTEXTURE) {


### PR DESCRIPTION
If we force hardware acceleration on a system where it's not available
SDL won't pick the software render driver as a fallback, resulting in a
black screen and an unplayable game (tested on WSLv1).
This commit lets SDL decide (it will prioritize a driver with hardware
acceleration anyway) which allows the game to run on platforms lacking
hardware acceleration without having to recompile, but let the user
enforce both options if they so wish.