### PR TITLE
Register quick key presses

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -1931,7 +1931,7 @@ void draw_select_level_dialog(void) {
 int need_full_menu_redraw_count;
 
 void draw_menu() {
-	escape_key_suppressed = (key_states[SDL_SCANCODE_BACKSPACE] || key_states[SDL_SCANCODE_ESCAPE]);
+	escape_key_suppressed = (key_states[SDL_SCANCODE_BACKSPACE] & KEYSTATE_HELD || key_states[SDL_SCANCODE_ESCAPE] & KEYSTATE_HELD);
 	surface_type* saved_target_surface = current_target_surface;
 	current_target_surface = overlay_surface;
 
@@ -2295,7 +2295,7 @@ void load_ingame_settings(void) {
 void menu_was_closed(void) {
 	is_paused = 0;
 	is_menu_shown = 0;
-	escape_key_suppressed = (key_states[SDL_SCANCODE_BACKSPACE] || key_states[SDL_SCANCODE_ESCAPE]);
+	escape_key_suppressed = (key_states[SDL_SCANCODE_BACKSPACE] & KEYSTATE_HELD || key_states[SDL_SCANCODE_ESCAPE] & KEYSTATE_HELD);
 	if (were_settings_changed) {
 		save_ingame_settings();
 		were_settings_changed = false;

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -520,8 +520,8 @@ void check_quick_op() {
 
 Uint32 temp_shift_release_callback(Uint32 interval, void *param) {
 	const Uint8* state = SDL_GetKeyboardState(NULL);
-	if (state[SDL_SCANCODE_LSHIFT] & KEYSTATE_HELD) key_states[SDL_SCANCODE_LSHIFT] |= KEYSTATE_HELD;
-	if (state[SDL_SCANCODE_RSHIFT] & KEYSTATE_HELD) key_states[SDL_SCANCODE_RSHIFT] |= KEYSTATE_HELD;
+	if (state[SDL_SCANCODE_LSHIFT]) key_states[SDL_SCANCODE_LSHIFT] |= KEYSTATE_HELD;
+	if (state[SDL_SCANCODE_RSHIFT]) key_states[SDL_SCANCODE_RSHIFT] |= KEYSTATE_HELD;
 	return 0; // causes the timer to be removed
 }
 
@@ -668,8 +668,8 @@ int process_key() {
 			if (current_level < custom->shift_L_allowed_until_level /* 4 */ || cheats_enabled) {
 				// if Shift is not released within the delay, the cutscene is skipped
 				Uint32 delay = 250;
-				key_states[SDL_SCANCODE_LSHIFT] &= ~KEYSTATE_HELD;
-				key_states[SDL_SCANCODE_RSHIFT] &= ~KEYSTATE_HELD;
+				key_states[SDL_SCANCODE_LSHIFT] = 0;
+				key_states[SDL_SCANCODE_RSHIFT] = 0;
 				SDL_TimerID timer;
 				timer = SDL_AddTimer(delay, temp_shift_release_callback, NULL);
 				if (timer == 0) {

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -520,8 +520,8 @@ void check_quick_op() {
 
 Uint32 temp_shift_release_callback(Uint32 interval, void *param) {
 	const Uint8* state = SDL_GetKeyboardState(NULL);
-	if (state[SDL_SCANCODE_LSHIFT]) key_states[SDL_SCANCODE_LSHIFT] |= KEYSTATE_HELD;
-	if (state[SDL_SCANCODE_RSHIFT]) key_states[SDL_SCANCODE_RSHIFT] |= KEYSTATE_HELD;
+	if (state[SDL_SCANCODE_LSHIFT]) key_states[SDL_SCANCODE_LSHIFT] |= KEYSTATE_HELD | KEYSTATE_HELD_NEW;
+	if (state[SDL_SCANCODE_RSHIFT]) key_states[SDL_SCANCODE_RSHIFT] |= KEYSTATE_HELD | KEYSTATE_HELD_NEW;
 	return 0; // causes the timer to be removed
 }
 

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -1711,6 +1711,12 @@ int do_paused() {
 		}
 		erase_bottom_text(1);
 	}
+
+	// As we processed input for current gameplay tick remove the bit flagging any button press as new
+	for(int i = 0; i < SDL_NUM_SCANCODES; i++) {
+		key_states[i] &= ~KEYSTATE_HELD_NEW;
+	}
+
 	return key || control_shift;
 }
 
@@ -1747,29 +1753,6 @@ void read_keyb_control() {
 		else if (key_states[SDL_SCANCODE_LEFTBRACKET] & (KEYSTATE_HELD | KEYSTATE_HELD_NEW)) --Char.x;
 	}
 	#endif
-
-	key_states[SDL_SCANCODE_UP] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_HOME] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_PAGEUP] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_KP_8] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_KP_7] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_KP_9] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_CLEAR] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_DOWN] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_KP_5] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_KP_2] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_LEFT] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_HOME] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_KP_4] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_KP_7] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_RIGHT] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_PAGEUP] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_KP_6] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_KP_9] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_LSHIFT] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_RSHIFT] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_RIGHTBRACKET] &= ~KEYSTATE_HELD_NEW;
-	key_states[SDL_SCANCODE_LEFTBRACKET] &= ~KEYSTATE_HELD_NEW;
 }
 
 // seg000:156D

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -3354,13 +3354,13 @@ void process_events() {
 				    scancode == SDL_SCANCODE_RETURN)
 				{
 					// Only if the Enter key was pressed down right now.
-					if (key_states[scancode] == 0) {
+					if ((key_states[scancode] & KEYSTATE_HELD) == 0) {
 						// Alt+Enter: toggle fullscreen mode
 						toggle_fullscreen();
-						key_states[scancode] = 1;
+						key_states[scancode] |= KEYSTATE_HELD | KEYSTATE_HELD_NEW;
 					}
 				} else {
-					key_states[scancode] = 1;
+					key_states[scancode] |= KEYSTATE_HELD | KEYSTATE_HELD_NEW;
 					switch (scancode) {
 						// Keys that are ignored by themselves:
 						case SDL_SCANCODE_LCTRL:
@@ -3434,7 +3434,7 @@ void process_events() {
 				}
 #endif
 
-				key_states[event.key.keysym.scancode] = 0;
+				key_states[event.key.keysym.scancode] &= ~KEYSTATE_HELD;
 #ifdef USE_MENU
 				// Prevent repeated keystrokes opening/closing the menu as long as the key is held down.
 				if (event.key.keysym.scancode == SDL_SCANCODE_BACKSPACE || event.key.keysym.scancode == SDL_SCANCODE_ESCAPE) {

--- a/src/types.h
+++ b/src/types.h
@@ -1348,6 +1348,14 @@ typedef struct directory_listing_type directory_listing_type;
 
 #define FEATHER_FALL_LENGTH 18.75
 
+// Bit-flags used for the keystate array
+enum
+{
+	KEYSTATE_HELD = (1<<0), // True if key is currently held down
+	KEYSTATE_HELD_NEW = (1<<1), // True if key was held down since since last gameplay tick
+	KEYSTATE_RELEASED_NEW = (1<<2), // True if key was let go since since last gameplay tick (TODO: Is this really necessary? We should be able to use KEYSTATE_HELD_NEW to tell if button press is a toggle since last game update)
+};
+
 // Enum used for input variables like control_up, control_forward, control_shift2, and etc
 enum
 {

--- a/src/types.h
+++ b/src/types.h
@@ -1352,8 +1352,7 @@ typedef struct directory_listing_type directory_listing_type;
 enum
 {
 	KEYSTATE_HELD = (1<<0), // True if key is currently held down
-	KEYSTATE_HELD_NEW = (1<<1), // True if key was held down since since last gameplay tick
-	KEYSTATE_RELEASED_NEW = (1<<2), // True if key was let go since since last gameplay tick (TODO: Is this really necessary? We should be able to use KEYSTATE_HELD_NEW to tell if button press is a toggle since last game update)
+	KEYSTATE_HELD_NEW = (1<<1), // True if key has been toggled on since last gameplay update
 };
 
 // Enum used for input variables like control_up, control_forward, control_shift2, and etc

--- a/src/types.h
+++ b/src/types.h
@@ -1363,7 +1363,6 @@ enum
 	// for control_shift, control_forward, control_backward, control_up, control_down, control_shift2:
 	CONTROL_IGNORE = 1,
 	CONTROL_HELD = -1,
-	//CONTROL_HELD_ALTDIRECTION = 1, // This is for the control_x and control_y variables to define they're being held down for the opposite direction (facing backwards for control_x and downwards for control_y)
 	// for control_x in seg000.c:
 	CONTROL_HELD_LEFT = -1,
 	CONTROL_HELD_RIGHT = 1,

--- a/src/types.h
+++ b/src/types.h
@@ -1351,8 +1351,8 @@ typedef struct directory_listing_type directory_listing_type;
 // Bit-flags used for the keystate array
 enum
 {
-	KEYSTATE_HELD = (1<<0), // True if key is currently held down
-	KEYSTATE_HELD_NEW = (1<<1), // True if key has been toggled on since last gameplay update
+	KEYSTATE_HELD = (1<<0), // Key is currently held down
+	KEYSTATE_HELD_NEW = (1<<1), // Key has been pressed since last gameplay update
 };
 
 // Enum used for input variables like control_up, control_forward, control_shift2, and etc


### PR DESCRIPTION
If the user is very quick with key presses (that is, the user presses and releases a key within the 83.333ms window between game updates), then the game ignores those key presses. This PR fixes that and makes the controls feel responsive overall. I find it's especially noticeable during combat where you might briefly tap up/shift to parry/attack.