### PR TITLE
Fix for letters above potions not showing up on the copy protection level.

### DIFF
--- a/src/seg007.c
+++ b/src/seg007.c
@@ -254,6 +254,13 @@ void animate_potion() {
 	if (trob.type >= 0 && is_trob_in_drawn_room()) {
 		word type = curr_modifier & 0xF8;
 		curr_modifier = bubble_next_frame(curr_modifier & 0x07) | type;
+#ifdef USE_COPYPROT
+		// the fix below does not display letters on the copy protection level
+		if (current_level == 15) {
+			set_redraw_anim_curr();
+			return;
+		}
+#endif
 #ifdef FIX_LOOSE_NEXT_TO_POTION
 		redraw_at_trob();
 #else


### PR DESCRIPTION
The drawing fix for a loose tile next to a potion makes letters on the copy protection level invisible.

The bug has been there for at least 2 releases.