### PR TITLE
Enable more paths for game loading, saving & storing the configuration for *NIX envs

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -33,6 +33,11 @@ The authors of this program may be contacted at https://forum.princed.org
 #define SDLPOP_VERSION "1.23"
 #define WINDOW_TITLE "Prince of Persia (SDLPoP) v" SDLPOP_VERSION
 
+#if ! defined WIN32 || _WIN32 || WIN64 || _WIN64
+#define POP_DIR_NAME "SDLPoP"
+#define SHARE_PATH "/usr/share"
+#endif
+
 // Enable or disable fading.
 // Fading used to be very buggy, but now it works correctly.
 #define USE_FADE

--- a/src/menu.c
+++ b/src/menu.c
@@ -2257,7 +2257,7 @@ void calculate_exe_crc(void) {
 }
 
 void save_ingame_settings(void) {
-	SDL_RWops* rw = SDL_RWFromFile(locate_file("SDLPoP.cfg"), "wb");
+	SDL_RWops* rw = SDL_RWFromFile(locate_save_file("SDLPoP.cfg"), "wb");
 	if (rw != NULL) {
 		calculate_exe_crc();
 		SDL_RWwrite(rw, &exe_crc, sizeof(exe_crc), 1);

--- a/src/proto.h
+++ b/src/proto.h
@@ -519,7 +519,9 @@ image_type* get_image(short chtab_id, int id);
 void sdlperror(const char* header);
 bool file_exists(const char* filename);
 #define locate_file(filename) locate_file_(filename, alloca(POP_MAX_PATH), POP_MAX_PATH)
+#define locate_save_file(filename) locate_save_file_(filename, alloca(POP_MAX_PATH), POP_MAX_PATH)
 const char* locate_file_(const char* filename, char* path_buffer, int buffer_size);
+const char* locate_save_file_(const char* filename, char* path_buffer, int buffer_size);
 
 #ifdef _WIN32
 

--- a/src/seg000.c
+++ b/src/seg000.c
@@ -2371,7 +2371,19 @@ void show_splash() {
 
 const char* get_writable_file_path(char* custom_path_buffer, size_t max_len, const char* file_name) {
 	// If the SDLPOP_SAVE_PATH environment variable is set, put all saves into the directory it points to.
+	// Otherwise, save to the home directory
+#if defined WIN32 || _WIN32 || WIN64 || _WIN64
 	const char* save_path = getenv("SDLPOP_SAVE_PATH");
+#else
+	char save_path[POP_MAX_PATH];
+	const char* custom_save_path = getenv("SDLPOP_SAVE_PATH");
+	const char* home_path = getenv("HOME");
+	if (custom_save_path != NULL && custom_save_path[0] != '\0')
+		snprintf_check(save_path, max_len, "%s", custom_save_path);
+	else if (home_path != NULL && home_path[0] != '\0')
+		snprintf_check(save_path, max_len, "%s/.%s", home_path, POP_DIR_NAME);
+#endif
+
 	if (save_path != NULL && save_path[0] != '\0') {
 #if defined WIN32 || _WIN32 || WIN64 || _WIN64
 		mkdir (save_path);

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -44,6 +44,12 @@ void sdlperror(const char* header) {
 
 char exe_dir[POP_MAX_PATH] = ".";
 bool found_exe_dir = false;
+#if ! defined WIN32 || _WIN32 || WIN64 || _WIN64
+char home_dir[POP_MAX_PATH];
+bool found_home_dir = false;
+char share_dir[POP_MAX_PATH];
+bool found_share_dir = false;
+#endif
 
 void find_exe_dir(void) {
 	if (found_exe_dir) return;
@@ -71,8 +77,42 @@ void find_exe_dir(void) {
 	found_exe_dir = true;
 }
 
+#if ! defined WIN32 || _WIN32 || WIN64 || _WIN64
+void find_home_dir(void) {
+	if (found_home_dir) return;
+	const char* home_path = getenv("HOME");
+	snprintf_check(home_dir, POP_MAX_PATH - 1, "%s/.%s", home_path, POP_DIR_NAME);
+	if(file_exists(home_dir))
+		found_home_dir = true;
+}
+
+void find_share_dir(void) {
+	if (found_share_dir) return;
+	snprintf_check(share_dir, POP_MAX_PATH - 1, "%s/%s", SHARE_PATH, POP_DIR_NAME);
+	if(file_exists(share_dir))
+		found_share_dir = true;
+}
+#endif
+
 bool file_exists(const char* filename) {
 	return (access(filename, F_OK) != -1);
+}
+
+const char* find_first_file_match(char* dst, int size, char* format, const char* filename) {
+	find_exe_dir();
+#if defined WIN32 || _WIN32 || WIN64 || _WIN64
+	snprintf_check(dst, size, format, exe_dir, filename);
+#else
+	find_home_dir();
+	find_share_dir();
+	char* dirs[3] = {home_dir, share_dir, exe_dir};
+	for (int i = 0; i < 3; i++) {
+		snprintf_check(dst, size, format, dirs[i], filename);
+		if(file_exists(dst))
+			break;
+	}
+#endif
+	return (const char*) dst;
 }
 
 const char* locate_file_(const char* filename, char* path_buffer, int buffer_size) {
@@ -81,9 +121,7 @@ const char* locate_file_(const char* filename, char* path_buffer, int buffer_siz
 	} else {
 		// If failed, it may be that SDLPoP is being run from the wrong different working directory.
 		// We can try to rescue the situation by loading from the directory of the executable.
-		find_exe_dir();
-		snprintf_check(path_buffer, buffer_size, "%s/%s", exe_dir, filename);
-		return (const char*) path_buffer;
+		return find_first_file_match(path_buffer, buffer_size, "%s/%s", filename);
 	}
 }
 
@@ -358,8 +396,7 @@ static FILE* open_dat_from_root_or_data_dir(const char* filename) {
 		snprintf_check(data_path, sizeof(data_path), "data/%s", filename);
 
 		if (!file_exists(data_path)) {
-			find_exe_dir();
-			snprintf_check(data_path, sizeof(data_path), "%s/data/%s", exe_dir, filename);
+			find_first_file_match(data_path, sizeof(data_path), "%s/data/%s", filename);
 		}
 
 		// verify that this is a regular file and not a directory (otherwise, don't open)

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -115,6 +115,25 @@ const char* find_first_file_match(char* dst, int size, char* format, const char*
 	return (const char*) dst;
 }
 
+const char* locate_save_file_(const char* filename, char* dst, int size) {
+	find_exe_dir();
+#if defined WIN32 || _WIN32 || WIN64 || _WIN64
+	snprintf_check(dst, size, "%s/%s", exe_dir, filename);
+#else
+	find_home_dir();
+	find_share_dir();
+	char* dirs[3] = {home_dir, share_dir, exe_dir};
+	for (int i = 0; i < 3; i++) {
+		struct stat path_stat;
+		int result = stat(dirs[i], &path_stat);
+		if (result == 0 && S_ISDIR(path_stat.st_mode) && access(dirs[i], W_OK) == 0) {
+			snprintf_check(dst, size, "%s/%s", dirs[i], filename);
+			break;
+		}
+	}
+#endif
+	return (const char*) dst;
+}
 const char* locate_file_(const char* filename, char* path_buffer, int buffer_size) {
 	if(file_exists(filename)) {
 		return filename;


### PR DESCRIPTION
The current file path scheme is inherited from DOS, where all the files resided in a single directory. In order to enable packaging the game for *NIX environments, the game shouldn't be restricted to reading the game files, save files or the configuration from the directory with the binary.

The search order for reading files is home directory (~/.SDLPoP) first, data directory (/usr/share/SDLPoP) and executable directory last. Saving the game or the configuration occurs into a directory found in the same order, with the first user-accessible directory is used.

Nothing is changed for WIN-based environments.