### PR TITLE
fixes compilation error for MSVC on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,8 @@ To compile, open one of the .dev files and click the compile icon.
        * https://github.com/libsdl-org/SDL/releases/latest
        * https://github.com/libsdl-org/SDL_image/releases/latest
        * Download the Visual C++ 32/64-bit development package, the `*-VC.zip` files.
+       * Copy SDL2_image folder contents into SDL2 folder so that their dlls and header files are placed at the same place, referenced by `SDL2` environmental variable for the compiler.
+       Add `SDL2` and `SDL2_image` dll folder to `PATH` for built executable to find them.
     * (You could create a small batch file to automate the above steps on your system.)
 * Alternatively, you can also build SDLPoP using MSVC with NMake (use the makefile src/NMakefile).
 

--- a/src/build.bat
+++ b/src/build.bat
@@ -54,7 +54,7 @@ set PreprocessorDefinitions=
 :compile
 set SourceFiles= main.c data.c seg000.c seg001.c seg002.c seg003.c seg004.c seg005.c seg006.c seg007.c seg008.c seg009.c seqtbl.c replay.c options.c lighting.c screenshot.c menu.c midi.c opl3.c stb_vorbis.c
 set CommonCompilerFlags= /nologo /MP /fp:fast /GR- /wd4048 %PreprocessorDefinitions% /I"%SDL2%\include"
-set CommonLinkerFlags= /subsystem:windows,5.01 /libpath:"%SDL2%\lib\%VSCMD_ARG_TGT_ARCH%" SDL2main.lib SDL2.lib SDL2_image.lib icon.res /out:..\prince.exe
+set CommonLinkerFlags= /subsystem:windows,5.01 /libpath:"%SDL2%\lib\%VSCMD_ARG_TGT_ARCH%" SDL2main.lib SDL2.lib SDL2_image.lib Shell32.lib icon.res /out:..\prince.exe
 
 rc /nologo /fo icon.res icon.rc
 cl %BuildTypeCompilerFlags% %CommonCompilerFlags% %SourceFiles% /link %CommonLinkerFlags%

--- a/src/seg009.c
+++ b/src/seg009.c
@@ -184,7 +184,7 @@ int access_UTF8(const char* filename_UTF8, int mode) {
 int stat_UTF8(const char *filename_UTF8, struct stat *_Stat) {
 	WCHAR* filename_UTF16 = WIN_UTF8ToString(filename_UTF8);
 	// There is a _wstat() function as well, but it expects the second argument to be a different type than stat().
-	int result = wstat(filename_UTF16, _Stat);
+	int result = _wstat(filename_UTF16, _Stat);
 	SDL_free(filename_UTF16);
 	return result;
 }
@@ -2601,10 +2601,10 @@ void set_gr_mode(byte grmode) {
 #if _WIN32
 	// Tell Windows that the application is DPI aware, to prevent unwanted bitmap stretching.
 	// SetProcessDPIAware() is only available on Windows Vista and later, so we need to load it dynamically.
-	BOOL WINAPI (*SetProcessDPIAware)();
+	typedef BOOL (WINAPI *dpiaware)(SetProcessDPIAware);
 	HMODULE user32dll = LoadLibraryA("User32.dll");
 	if (user32dll) {
-		SetProcessDPIAware = GetProcAddress(user32dll, "SetProcessDPIAware");
+		dpiaware SetProcessDPIAware = (dpiaware)GetProcAddress(user32dll, "SetProcessDPIAware");
 		if (SetProcessDPIAware) {
 			SetProcessDPIAware();
 		}


### PR DESCRIPTION
Current SDLPop doesn't compile on Windows using MSVC/Visual Studio compiler. 
It throws 3 errors when trying to build on windows.
1. `SetProcessDPIAware` syntax issue
2. `__imp_CommandLineToArgvW`  definition not found during linker because `shell32.dll` was missing
3. `wstat` not found, replaced with `_wstat`.

It compiles and links correctly and produces a pop exe which plays. 

Bonus : adds missing build instructions to README