### PR TITLE
Fixed a turn-run bug that causes trick 1 and trick 2 to work.

### DIFF
--- a/SDLPoP.ini
+++ b/SDLPoP.ini
@@ -267,6 +267,9 @@ fix_drop_2_rooms_climbing_loose_tile = true
 ; Prince or guard can fall through the floor during a sword strike sequence.
 fix_falling_through_floor_during_sword_strike = true
 
+; Prince safe steps near a wall/gate when facing in an opposite direction (Fixes tricks 1 and 2).
+fix_turn_running_near_wall = true
+
 
 [CustomGameplay]
 ; Turn on customization options.

--- a/src/config.h
+++ b/src/config.h
@@ -291,6 +291,11 @@ The authors of this program may be contacted at https://forum.princed.org
 // See also: https://github.com/NagyD/SDLPoP/pull/274
 #define FIX_FALLING_THROUGH_FLOOR_DURING_SWORD_STRIKE
 
+// Prince can start running when he is standing really close to a wall/gate/tapestry but facing in a different direction.
+// He can either press buttons through gates or falling back when facing right against a closed gate when there is an abiss behind.
+// This fix ensures the logic that makes Prince safe-stepping instead of running is also working when he is facing in the opposite direction.
+#define FIX_TURN_RUN_NEAR_WALL
+
 // When the player (re-)enters the currently shown room, the guard disappears from the screen.
 // This can happen when:
 // * A room is linked to itself (broken link).

--- a/src/menu.c
+++ b/src/menu.c
@@ -204,6 +204,7 @@ enum setting_ids {
 	SETTING_FIX_DROP_2_ROOMS_CLIMBING_LOOSE_TILE,
 	SETTING_FIX_FALLING_THROUGH_FLOOR_DURING_SWORD_STRIKE,
 	SETTING_FIX_REGISTER_QUICK_INPUT,
+	SETTING_FIX_TURN_RUNNING_NEAR_WALL,
 	SETTING_ENABLE_SUPER_HIGH_JUMP,
 	SETTING_ENABLE_JUMP_GRAB,
 	SETTING_USE_CUSTOM_OPTIONS,
@@ -608,6 +609,10 @@ setting_type gameplay_settings[] = {
 				.linked = &fixes_saved.fix_register_quick_input, .required = &use_fixes_and_enhancements,
 				.text = "Fix fast inputs",
 				.explanation = "Input is ignored if a button or key is pressed and released between game ticks."},
+		{.id = SETTING_FIX_TURN_RUNNING_NEAR_WALL, .style = SETTING_STYLE_TOGGLE,
+				.linked = &fixes_saved.fix_turn_running_near_wall, .required = &use_fixes_and_enhancements,
+				.text = "Fix run turning near wall",
+				.explanation = "Ensures Prince safe steps near a wall/gate when facing in an opposite direction."},
 };
 
 NAMES_LIST(tile_type_setting_names, {

--- a/src/options.c
+++ b/src/options.c
@@ -292,6 +292,7 @@ static int global_ini_callback(const char *section, const char *name, const char
 		process_boolean("fix_falling_through_floor_during_sword_strike", &fixes_saved.fix_falling_through_floor_during_sword_strike);
 		process_boolean("enable_jump_grab", &fixes_saved.enable_jump_grab);
 		process_boolean("fix_register_quick_input", &fixes_saved.fix_register_quick_input);
+		process_boolean("fix_turn_running_near_wall", &fixes_saved.fix_turn_running_near_wall);
 	}
 
 	if (check_ini_section("CustomGameplay")) {

--- a/src/seg004.c
+++ b/src/seg004.c
@@ -387,7 +387,7 @@ int get_edge_distance() {
 		if (distance >= 0) {
 			loc_59DD:
 			if (distance <= TILE_RIGHTX) {
-				edge_type = EDGE_TYPE_EDGE;
+				edge_type = EDGE_TYPE_WALL;
 			} else {
 				edge_type = EDGE_TYPE_FLOOR;
 				distance = 11;

--- a/src/types.h
+++ b/src/types.h
@@ -1231,6 +1231,7 @@ typedef struct fixes_options_type {
 	byte fix_falling_through_floor_during_sword_strike;
 	byte enable_jump_grab;
 	byte fix_register_quick_input;
+	byte fix_turn_running_near_wall;
 } fixes_options_type;
 
 #define NUM_GUARD_SKILLS 12
@@ -1398,8 +1399,8 @@ enum
 enum
 {
 	EDGE_TYPE_CLOSER, // closer/sword/potion
-	EDGE_TYPE_EDGE, // edge
-	EDGE_TYPE_FLOOR, // floor (nothing near char)
+	EDGE_TYPE_WALL,   // wall/gate/tapestry/mirror/chomper
+	EDGE_TYPE_FLOOR,  // floor (nothing near char)
 };
 
 #define TILE_SIZEX 14 // Horizontal size of tile in the internal coordinate system (a tile is 32 pixels wide in screen space)


### PR DESCRIPTION
I stumbled on this issue when looking at PoP2 bug where Prince can turn-run into walls and use sword to push himself through. The walls there act differently because they are considered floors. But the general issue has been there since PoP1.

If you stay within 8 pixels or less from the wall/gate/tapestry when facing it and hold the forward arrow, Prince is going to do a safe step. But if you face in the opposite direction and hold the back arrow, the game starts the "turnrun" sequence without doing that check. That sequence pushes Prince back one pixel then jumps to the start of the "startrun" sequence. I assume that was done to make the animation a tiny bit smoother as 1 pixel shift is not going to fix bugs that are caused by running frames with a large weight offset value.

I added the wall distance check in the turn-run logic of the code and let the control_forward() method handle the safe step normally if Prince is close to a wall. I also corrected one of the edge_type enum names.

The configurable fix prevents trick 1 and trick 2 on popot.org as well as fixes the issue where Prince can fall back trying to do those tricks when there is an empty tile to the left of the gate.