### PR TITLE
Screenshot.c stack-buffer-overflow fix

### DIFF
--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -489,7 +489,7 @@ void save_level_screenshot(bool want_extras) {
 	}
 	xpos[drawn_room] = 0;
 	ypos[drawn_room] = 0;
-	int queue[NUMBER_OF_ROOMS] = {drawn_room}; // We start mapping from the current room.
+	int queue[NUMBER_OF_ROOMS+1] = {drawn_room}; // We start mapping from the current room.
 	int queue_start = 0;
 	int queue_end = 1;
 


### PR DESCRIPTION
Screenshot queue can overflow on levels with 24 of rooms. Normally the game does not crash but can cause minor pixel imperfections in the screenshot. But it does crash with the `-fsanitize=address` flag.
```
  This frame has 4 object(s):
    [32, 48) 'dest_rect' (line 659)
    [64, 89) 'processed' (line 485)
    [128, 224) 'queue' (line 492) <== Memory access at offset 224 overflows this variable
SUMMARY: AddressSanitizer: stack-buffer-overflow (/home/ds/SDLPOP/prince+0xad9d4) (BuildId: e09a5b0d06d3d793a283f81da478a14adaa87e77) in save_level_screenshot
```